### PR TITLE
fix: comprehensive hardening of daily prediction pipeline

### DIFF
--- a/.github/workflows/daily-grade.yml
+++ b/.github/workflows/daily-grade.yml
@@ -32,5 +32,5 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add mlb_bets.db docs/data/
           git diff --cached --quiet || git commit -m "chore: grade predictions $(date -u +%Y-%m-%d)"
-          git pull --rebase origin master
+          git pull --rebase -X theirs origin master
           git push origin master

--- a/.github/workflows/daily-predict.yml
+++ b/.github/workflows/daily-predict.yml
@@ -67,5 +67,5 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add mlb_bets.db docs/data/
           git diff --cached --quiet || git commit -m "chore: predictions $(date -u +%Y-%m-%d)"
-          git pull --rebase origin master
+          git pull --rebase -X theirs origin master
           git push origin master

--- a/.github/workflows/weekly-retrain.yml
+++ b/.github/workflows/weekly-retrain.yml
@@ -37,4 +37,6 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add models/*.joblib models/training_state.json
-          git diff --cached --quiet || (git commit -m "chore: retrain models $(date -u +%Y-%m-%d)" && git push)
+          git diff --cached --quiet || git commit -m "chore: retrain models $(date -u +%Y-%m-%d)"
+          git pull --rebase -X theirs origin master
+          git push origin master

--- a/main.py
+++ b/main.py
@@ -75,7 +75,13 @@ def run_predictions(model_name: str = "xgboost"):
 
     # Step 1: Fetch today's games
     print("\n  [1/5] Fetching today's games...")
-    games = get_todays_games()
+    try:
+        games = get_todays_games()
+    except Exception as e:
+        print(f"  ERROR: MLB Stats API unavailable — {e}")
+        export_dashboard_data()
+        post_picks_to_discord([])
+        return
     if not games:
         print("  No games found today (off day or no probable pitchers posted). Exiting.")
         return  # Not an error — valid off day
@@ -87,8 +93,10 @@ def run_predictions(model_name: str = "xgboost"):
         model = load_model(model_name)
     except FileNotFoundError as e:
         print(f"  ERROR: {e}")
-        print("  Run 'python train.py' first to train the models.")
-        sys.exit(1)
+        print("  Models must be trained before running predictions.")
+        export_dashboard_data()
+        post_picks_to_discord([])
+        return
 
     # Step 3: Build features and predict
     print("\n  [3/5] Building features and predicting...")
@@ -99,19 +107,28 @@ def run_predictions(model_name: str = "xgboost"):
             logger.warning("Using default 0.5 prob for %s @ %s",
                            game["away_team"], game["home_team"])
         else:
-            game["model_prob"] = predict_win_prob(model, features)
+            try:
+                game["model_prob"] = predict_win_prob(model, features)
+            except Exception as e:
+                logger.warning("Prediction failed for %s @ %s: %s — using 0.5",
+                               game["away_team"], game["home_team"], e)
+                game["model_prob"] = 0.5
         game["model_name"] = model_name
 
     # Step 4: Fetch odds and match
     print("\n  [4/5] Fetching live odds...")
     odds = fetch_live_odds()
     if not odds:
-        print("  ERROR: Could not fetch odds (check ODDS_API_KEY). Cannot calculate EV.")
-        sys.exit(1)
+        print("  WARNING: Could not fetch odds (check ODDS_API_KEY). No picks today.")
+        export_dashboard_data()
+        post_picks_to_discord([])
+        return
     games_with_odds = match_odds_to_games(odds, games)
     if not games_with_odds:
-        print("  ERROR: No games matched with odds (possible team name mapping issue).")
-        sys.exit(1)
+        print("  WARNING: No games matched with odds (possible team name mapping issue). No picks today.")
+        export_dashboard_data()
+        post_picks_to_discord([])
+        return
     print(f"        Matched odds for {len(games_with_odds)} games.")
 
     # Step 5: Calculate EV and filter
@@ -144,7 +161,12 @@ def run_grading():
     print(f"{'='*60}")
 
     print("\n  Fetching yesterday's results...")
-    results = get_yesterdays_results()
+    try:
+        results = get_yesterdays_results()
+    except Exception as e:
+        print(f"  ERROR: MLB Stats API unavailable — {e}")
+        export_dashboard_data()
+        return
     if not results:
         print("  No results found for yesterday. Exiting.")
         return

--- a/model.py
+++ b/model.py
@@ -353,13 +353,19 @@ def predict_win_prob(model, features: dict) -> float:
         try:
             inner = model.calibrated_classifiers_[0].estimator
             if hasattr(inner, "get_booster"):
+                # XGBoost: booster always stores feature names regardless of sklearn version
                 fn = inner.get_booster().feature_names
+                if fn:
+                    model_cols = fn
+            elif hasattr(inner, "feature_names_in_"):
+                # Pipeline (e.g. Logistic Regression): sklearn sets this when fit with a DataFrame
+                fn = list(inner.feature_names_in_)
                 if fn:
                     model_cols = fn
         except Exception:
             pass
 
-    if model_cols is not None:
+    if model_cols:  # empty list is falsy — avoids zero-column DataFrame crash
         X = X.reindex(columns=model_cols, fill_value=0.0)
 
     prob = model.predict_proba(X)[0][1]  # probability of class 1 (home win)

--- a/odds.py
+++ b/odds.py
@@ -58,9 +58,13 @@ def fetch_live_odds() -> list[dict]:
         "oddsFormat": "american",
     }
 
-    resp = requests.get(url, params=params, timeout=30)
-    resp.raise_for_status()
-    raw = resp.json()
+    try:
+        resp = requests.get(url, params=params, timeout=30)
+        resp.raise_for_status()
+        raw = resp.json()
+    except Exception as e:
+        logger.error("The-Odds-API request failed: %s", e)
+        return []
 
     odds_list = []
     for event in raw:


### PR DESCRIPTION
## Summary

- **Binary conflict fix**: All three workflows (`daily-predict.yml`, `daily-grade.yml`, `weekly-retrain.yml`) now use `git pull --rebase -X theirs origin master` before pushing. This prevents a rebase conflict on `mlb_bets.db` when two workflows push to master at the same time (e.g. grading runs while predictions are finishing).

- **MLB Stats API outage**: `get_todays_games()` and `get_yesterdays_results()` are now wrapped in `try/except`. If the API is down after all retries, the job exits gracefully — exports the dashboard JSON and posts a "no picks" Discord message — instead of crashing the Actions step.

- **Missing model file**: Replaced `sys.exit(1)` on `FileNotFoundError` with a graceful return so the dashboard is always exported even if model files are absent.

- **Per-game inference crash**: Each `predict_win_prob()` call is now guarded individually. A crash on one game falls back to `0.5` probability and logs a warning; the rest of the slate still runs.

- **Model feature mismatch (old models)**: `predict_win_prob()` now has a three-tier column-filtering fallback — `feature_names_in_` → XGBoost booster `feature_names` → Pipeline `feature_names_in_` — so pre-sklearn-1.0 and pre-retrain models don't crash.

- **Odds API error**: The HTTP call to The-Odds-API is wrapped in `try/except`; any HTTP error (401/403/429/timeout) returns `[]` instead of raising.

## Test plan

- [ ] Merge and watch the next scheduled `daily-predict` run (13:30 UTC) complete without errors
- [ ] Trigger `workflow_dispatch` on `daily-predict` to verify manual runs work
- [ ] Verify `docs/data/picks_today.json` and `docs/data/stats.json` are updated after the run