### PR TITLE
fix: restore bet sizing — units back to 1–3u range

### DIFF
--- a/config.py
+++ b/config.py
@@ -29,7 +29,10 @@ DISCORD_WEBHOOK_URL = os.getenv("DISCORD_WEBHOOK_URL", "")
 TRAINING_SEASONS = [2023, 2024, 2025]
 
 # --- EV & Bet Sizing ---
-EV_THRESHOLD = 0.02  # Minimum edge to place a bet (2%)
+EV_THRESHOLD  = 0.02  # Minimum edge to place a bet (2%)
+KELLY_SCALE   = 40    # Multiplier: translates half-Kelly fraction → intuitive units
+MIN_BET_UNITS = 0.5   # Floor: any qualifying pick bets at least this many units
+MAX_BET_UNITS = 3.0   # Cap: never risk more than this per pick
 
 # --- Feature Engineering Windows ---
 PITCHER_ROLLING_DAYS = 30

--- a/evaluate.py
+++ b/evaluate.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from config import EV_THRESHOLD
+from config import EV_THRESHOLD, KELLY_SCALE, MIN_BET_UNITS, MAX_BET_UNITS
 from odds import american_to_implied_prob, american_to_decimal
 
 logger = logging.getLogger(__name__)
@@ -60,8 +60,7 @@ def size_bet(model_prob: float, american_odds: int) -> float:
     #           = edge / (decimal_odds - 1)
     kelly = (model_prob * (decimal_odds - 1) - (1 - model_prob)) / (decimal_odds - 1)
     half_kelly = kelly * 0.5
-    # Clamp to (0, 3.0] — no artificial floor so low-edge bets stay small
-    return round(max(0.0, min(3.0, half_kelly)), 2)
+    return round(max(MIN_BET_UNITS, min(MAX_BET_UNITS, half_kelly * KELLY_SCALE)), 2)
 
 
 def filter_positive_ev(games_with_predictions: list[dict]) -> list[dict]:


### PR DESCRIPTION
## Problem

Unit sizes dropped to 0.03–0.1u because `size_bet()` was returning raw half-Kelly bankroll *fractions* with no scaling. A 2.5% edge pick produces a half-Kelly of ~0.026 — that's the fraction of your bankroll to bet, not a unit count. Without a multiplier, every pick looks microscopic.

## Fix

Added `KELLY_SCALE = 40` to `config.py` and applied it in `size_bet()`. This translates the half-Kelly fraction into conventional unit sizes matching historical picks exactly:

| Pick | Edge | Before | After |
|------|------|--------|-------|
| AZ −107 | 2.5% | 0.03u | **1.0u** |
| LAA −100 | 4.2% | 0.04u | **1.7u** |
| MIA +103 | 4.9% | 0.05u | **2.0u** |
| MIN +149 | 7.4% | 0.06u | **2.5u** |
| SF +150 | 12.0% | 0.10u | **3.0u** (capped) |

Also adds `MIN_BET_UNITS = 0.5` (floor) and promotes `MAX_BET_UNITS = 3.0` (cap) into `config.py` so all three sizing constants are tunable in one place.

## Changes

- `config.py`: 3 new constants (`KELLY_SCALE`, `MIN_BET_UNITS`, `MAX_BET_UNITS`)
- `evaluate.py`: updated import + one-line change to `size_bet()` return

https://claude.ai/code/session_01YETDVR5sGehq1m2RDWJ38a