### PR TITLE
Migrate Tailwind to CSS and improve auth resilience

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -378,13 +378,16 @@ tr.row-pending td:first-child { border-left: 3px solid var(--border); }
 .subscribe-btn {
   display: inline-block;
   background: var(--accent);
+  border: none;
   color: #fff;
   padding: 8px 14px;
   border-radius: var(--radius);
   font-size: 13px;
   font-weight: 600;
+  font-family: var(--font);
   text-align: center;
   text-decoration: none;
+  cursor: pointer;
   transition: background .15s;
 }
 .subscribe-btn:hover { background: #1a60d0; color: #fff; }

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,29 +8,6 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="css/style.css" />
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js"></script>
-  <script src="https://cdn.tailwindcss.com"></script>
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            brand:   { 900: '#05080f', 800: '#0a1020', 700: '#111827' },
-            surface: '#161b22',
-            border:  '#30363d',
-            muted:   '#8b949e',
-            accent:  '#00c2ff',
-            gold:    '#f0b429',
-            emerald: '#00e5a0',
-            crimson: '#ff4b6e',
-            green:   '#3fb950',
-            red:     '#f85149',
-            blue:    '#58a6ff',
-          },
-          fontFamily: { sans: ['Inter', 'system-ui', 'sans-serif'] },
-        }
-      }
-    }
-  </script>
 </head>
 <body>
 
@@ -42,7 +19,16 @@
       </div>
       <div class="header-right">
         <div id="last-updated" class="last-updated">Loading…</div>
-        <div id="header-auth" class="header-auth"></div>
+        <div id="header-auth" class="header-auth">
+          <div id="auth-logged-out" style="display:flex;gap:8px;align-items:center">
+            <button class="auth-btn" onclick="openModal('signin')">Sign in</button>
+            <button class="auth-btn auth-btn-primary" onclick="openModal('signup')">Get access</button>
+          </div>
+          <div id="auth-logged-in" style="display:none;gap:8px;align-items:center">
+            <span id="auth-user-email" class="auth-email"></span>
+            <button class="auth-btn" onclick="sbSignOut()">Sign out</button>
+          </div>
+        </div>
       </div>
     </div>
   </header>
@@ -193,6 +179,28 @@
       </div>
     </div>
   </div>
+
+  <!-- Inline stubs: guarantee these globals exist even if auth.js fails to load -->
+  <script>
+    function openModal(tab) {
+      var m = document.getElementById('auth-modal');
+      if (!m) return;
+      m.style.display = 'flex';
+      var active = tab || 'signin';
+      document.querySelectorAll('.modal-tab').forEach(function(t) {
+        t.classList.toggle('active', t.dataset.tab === active);
+      });
+      document.querySelectorAll('.modal-panel').forEach(function(p) {
+        p.style.display = (p.dataset.panel === active) ? 'flex' : 'none';
+      });
+    }
+    function closeModal() {
+      var m = document.getElementById('auth-modal');
+      if (m) m.style.display = 'none';
+    }
+    function startSubscription() { openModal('signup'); }
+    function sbSignOut() {}
+  </script>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
   <script src="js/auth.js"></script>

--- a/docs/js/auth.js
+++ b/docs/js/auth.js
@@ -6,7 +6,10 @@ const SUPABASE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const PICKS_FN    = `${SUPABASE_URL}/functions/v1/get-picks-data`;
 const CHECKOUT_FN = `${SUPABASE_URL}/functions/v1/create-checkout-session`;
 
-const sb = window.supabase.createClient(SUPABASE_URL, SUPABASE_KEY);
+if (!window.supabase?.createClient) {
+  console.warn('Supabase SDK not available — auth features disabled.');
+}
+const sb = window.supabase?.createClient(SUPABASE_URL, SUPABASE_KEY) ?? null;
 
 // ── Shared auth state (read by dashboard.js) ───────────────────────────────
 window.sbUser       = null;
@@ -15,7 +18,7 @@ window.sbSubscribed = false;
 
 // ── Subscription check ─────────────────────────────────────────────────────
 async function _checkSub() {
-  if (!window.sbUser) { window.sbSubscribed = false; return; }
+  if (!window.sbUser || !sb) { window.sbSubscribed = false; return; }
   const { data } = await sb
     .from('profiles')
     .select('subscription_status')
@@ -68,21 +71,22 @@ window.startSubscription = async function () {
 
 // ── Header auth bar ────────────────────────────────────────────────────────
 function _updateHeader() {
-  const el = document.getElementById('header-auth');
-  if (!el) return;
+  const loggedOut = document.getElementById('auth-logged-out');
+  const loggedIn  = document.getElementById('auth-logged-in');
+  const emailEl   = document.getElementById('auth-user-email');
+  if (!loggedOut || !loggedIn) return;
   if (window.sbUser) {
-    el.innerHTML = `
-      <span class="auth-email">${window.sbUser.email}</span>
-      <button class="auth-btn" onclick="sbSignOut()">Sign out</button>`;
+    loggedOut.style.display = 'none';
+    loggedIn.style.display  = 'flex';
+    if (emailEl) emailEl.textContent = window.sbUser.email;
   } else {
-    el.innerHTML = `
-      <button class="auth-btn" onclick="openModal('signin')">Sign in</button>
-      <button class="auth-btn auth-btn-primary" onclick="openModal('signup')">Get access</button>`;
+    loggedOut.style.display = 'flex';
+    loggedIn.style.display  = 'none';
   }
 }
 
 // ── Auth actions ───────────────────────────────────────────────────────────
-window.sbSignOut = async function () { await sb.auth.signOut(); };
+window.sbSignOut = async function () { if (sb) await sb.auth.signOut(); };
 
 // ── Modal ──────────────────────────────────────────────────────────────────
 window.openModal = function (tab) {
@@ -116,6 +120,7 @@ function _clearErr() { _err(''); }
 // ── Form submissions ───────────────────────────────────────────────────────
 async function _onSignIn(e) {
   e.preventDefault();
+  if (!sb) { _err('Auth not available.'); return; }
   _clearErr();
   const email = document.getElementById('si-email').value.trim();
   const pw    = document.getElementById('si-pw').value;
@@ -133,6 +138,7 @@ async function _onSignIn(e) {
 
 async function _onSignUp(e) {
   e.preventDefault();
+  if (!sb) { _err('Auth not available.'); return; }
   _clearErr();
   const email = document.getElementById('su-email').value.trim();
   const pw    = document.getElementById('su-pw').value;
@@ -158,6 +164,7 @@ async function _onSignUp(e) {
 
 // ── Init ───────────────────────────────────────────────────────────────────
 async function _init() {
+  if (!sb) { _updateHeader(); return; }
   const { data: { session } } = await sb.auth.getSession();
   window.sbSession = session;
   window.sbUser    = session?.user ?? null;


### PR DESCRIPTION
## Summary
This PR removes the inline Tailwind CSS configuration and migrates to a dedicated CSS stylesheet approach. It also improves the robustness of authentication features by adding graceful fallbacks when the Supabase SDK fails to load.

## Key Changes

- **Remove inline Tailwind configuration**: Deleted the `<script src="https://cdn.tailwindcss.com">` tag and its associated `tailwind.config` object from `index.html`. All styling is now handled by `css/style.css`.

- **Refactor auth UI rendering**: Moved hardcoded auth button HTML from JavaScript into static HTML elements in `index.html` (`auth-logged-out` and `auth-logged-in` divs). The auth state now toggles visibility of these pre-existing elements instead of dynamically generating HTML.

- **Add auth stub functions**: Implemented inline stub functions (`openModal`, `closeModal`, `startSubscription`, `sbSignOut`) in `index.html` to guarantee these globals exist even if `auth.js` fails to load, preventing runtime errors.

- **Improve Supabase SDK resilience**: Added null-safety checks in `auth.js`:
  - Check if `window.supabase.createClient` exists before using it
  - Allow `sb` to be `null` if SDK is unavailable
  - Guard all Supabase operations with `if (sb)` checks
  - Show user-friendly error messages when auth is unavailable

- **CSS improvements**: Enhanced `.subscribe-btn` styling in `style.css` by adding explicit `border: none`, `font-family`, and `cursor: pointer` properties for better consistency and usability.

## Notable Implementation Details

- The auth header now uses CSS `display` toggling (flex/none) instead of innerHTML manipulation, improving performance and reducing XSS surface area.
- The stub functions allow the page to remain functional even if the Supabase SDK CDN fails to load, with graceful degradation.
- All auth-dependent operations now safely check for `sb` existence before attempting to use it.

https://claude.ai/code/session_01Hr1yvS5gnJHLwZ4LgA7Uas