### PR TITLE
Add subscription management and promo code redemption

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -666,6 +666,143 @@ tr.row-pending td:first-child { border-left: 3px solid var(--border); }
 .paywall-sub-btn:hover:not(:disabled) { background: #1a60d0; }
 .paywall-sub-btn:disabled { opacity: .6; cursor: not-allowed; }
 
+/* ── Manage subscription modal ───────────────────────────────── */
+.modal-title-row { margin-bottom: 20px; }
+.modal-heading   { font-size: 16px; font-weight: 600; }
+
+.manage-body { display: flex; flex-direction: column; gap: 16px; }
+
+.manage-status-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.status-pill {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .5px;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  border-radius: 20px;
+}
+
+.status-active   { background: rgba(0,229,160,.15);  color: var(--green); }
+.status-trial    { background: rgba(0,194,255,.15);  color: var(--blue);  }
+.status-lifetime { background: rgba(240,180,41,.15); color: var(--yellow);}
+.status-inactive { background: rgba(107,126,148,.12);color: var(--muted); }
+.status-pastdue  { background: rgba(248,81,73,.12);  color: var(--red);   }
+
+.manage-meta {
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.manage-cancel-section {
+  border-top: 1px solid var(--border);
+  padding-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.manage-cancel-info {
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.cancel-btn {
+  align-self: flex-start;
+  background: transparent;
+  border: 1px solid rgba(248,81,73,.5);
+  border-radius: var(--radius);
+  color: var(--red);
+  cursor: pointer;
+  font-family: var(--font);
+  font-size: 13px;
+  font-weight: 500;
+  padding: 7px 14px;
+  transition: background .15s, border-color .15s;
+}
+.cancel-btn:hover:not(:disabled) {
+  background: rgba(248,81,73,.08);
+  border-color: var(--red);
+}
+.cancel-btn:disabled { opacity: .55; cursor: not-allowed; }
+
+/* ── Promo code form (in paywall) ─────────────────────────────── */
+.promo-section {
+  margin-top: 4px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+
+.promo-toggle-link {
+  font-size: 12px;
+  color: var(--muted);
+  text-decoration: underline;
+  cursor: pointer;
+}
+.promo-toggle-link:hover { color: var(--text); }
+
+.promo-inline-form {
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  max-width: 280px;
+}
+
+.promo-input {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  font-family: var(--font);
+  font-size: 14px;
+  padding: 8px 12px;
+  outline: none;
+  width: 100%;
+  text-align: center;
+  letter-spacing: 1px;
+  transition: border-color .15s;
+}
+.promo-input:focus { border-color: var(--accent); }
+
+.promo-submit-btn {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  cursor: pointer;
+  font-family: var(--font);
+  font-size: 13px;
+  font-weight: 500;
+  padding: 7px 16px;
+  transition: border-color .15s;
+  width: 100%;
+}
+.promo-submit-btn:hover:not(:disabled) { border-color: var(--muted); }
+.promo-submit-btn:disabled { opacity: .6; cursor: not-allowed; }
+
+.promo-error {
+  background: rgba(248,81,73,.1);
+  border: 1px solid rgba(248,81,73,.3);
+  border-radius: 6px;
+  color: var(--red);
+  font-size: 12px;
+  padding: 6px 10px;
+  width: 100%;
+  text-align: center;
+}
+
 /* ── Stat card gradient border upgrade ───────────────────────── */
 .stat-card {
   background: var(--surface);

--- a/docs/index.html
+++ b/docs/index.html
@@ -26,6 +26,7 @@
           </div>
           <div id="auth-logged-in" style="display:none;gap:8px;align-items:center">
             <span id="auth-user-email" class="auth-email"></span>
+            <button id="auth-manage-btn" class="auth-btn" style="display:none" onclick="openManageModal()">Manage</button>
             <button class="auth-btn" onclick="sbSignOut()">Sign out</button>
           </div>
         </div>
@@ -89,8 +90,8 @@
           </div>
           <div class="subscribe-banner">
             <div class="sub-title">Unlock today's picks</div>
-            <div class="sub-desc">Edge, EV, confidence ratings &amp; full analysis — $7.99/month. Cancel anytime.</div>
-            <button class="subscribe-btn subscribe-cta" onclick="startSubscription()">Subscribe — $7.99/mo</button>
+            <div class="sub-desc">5-day free trial, then $7.99/month. Cancel anytime.</div>
+            <button class="subscribe-btn subscribe-cta" onclick="startSubscription()">Start Free Trial</button>
           </div>
         </div>
       </div>
@@ -175,7 +176,20 @@
           <div class="modal-error" style="display:none"></div>
           <button id="su-btn" type="submit" class="modal-submit">Create account</button>
         </form>
-        <p class="modal-note">After creating your account you'll be taken to checkout to start your $7.99/month subscription.</p>
+        <p class="modal-note">After creating your account you'll start a 5-day free trial, then $7.99/month. Cancel anytime.</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── Manage subscription modal ───────────────────────────── -->
+  <div id="manage-modal" class="auth-modal" style="display:none">
+    <div class="modal-content">
+      <button class="modal-close" onclick="closeManageModal()" aria-label="Close">&times;</button>
+      <div class="modal-title-row">
+        <h2 class="modal-heading">Subscription</h2>
+      </div>
+      <div id="manage-modal-body" class="manage-body">
+        <!-- rendered by auth.js _renderManageModal() -->
       </div>
     </div>
   </div>
@@ -196,6 +210,11 @@
     }
     function closeModal() {
       var m = document.getElementById('auth-modal');
+      if (m) m.style.display = 'none';
+    }
+    function openManageModal() {}
+    function closeManageModal() {
+      var m = document.getElementById('manage-modal');
       if (m) m.style.display = 'none';
     }
     function startSubscription() { openModal('signup'); }

--- a/docs/js/auth.js
+++ b/docs/js/auth.js
@@ -5,6 +5,8 @@ const SUPABASE_URL = 'https://hmukgvrpuncxkzeuujam.supabase.co';
 const SUPABASE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImhtdWtndnJwdW5jeGt6ZXV1amFtIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzgxOTMwNDgsImV4cCI6MjA5Mzc2OTA0OH0.0SC2M6Fro3dOwWwf-7Qld-aN3RjCusNkKUWVEalLtEM';
 const PICKS_FN    = `${SUPABASE_URL}/functions/v1/get-picks-data`;
 const CHECKOUT_FN = `${SUPABASE_URL}/functions/v1/create-checkout-session`;
+const CANCEL_FN   = `${SUPABASE_URL}/functions/v1/cancel-subscription`;
+const REDEEM_FN   = `${SUPABASE_URL}/functions/v1/redeem-promo`;
 
 if (!window.supabase?.createClient) {
   console.warn('Supabase SDK not available — auth features disabled.');
@@ -15,16 +17,26 @@ const sb = window.supabase?.createClient(SUPABASE_URL, SUPABASE_KEY) ?? null;
 window.sbUser       = null;
 window.sbSession    = null;
 window.sbSubscribed = false;
+window.sbSubStatus  = 'inactive';  // 'inactive' | 'trialing' | 'active' | 'past_due' | 'lifetime'
+window.sbSubEnd     = null;        // ISO date string of period/trial end
 
 // ── Subscription check ─────────────────────────────────────────────────────
 async function _checkSub() {
-  if (!window.sbUser || !sb) { window.sbSubscribed = false; return; }
+  if (!window.sbUser || !sb) {
+    window.sbSubscribed = false;
+    window.sbSubStatus  = 'inactive';
+    window.sbSubEnd     = null;
+    return;
+  }
   const { data } = await sb
     .from('profiles')
-    .select('subscription_status')
+    .select('subscription_status, subscription_end')
     .eq('user_id', window.sbUser.id)
     .single();
-  window.sbSubscribed = data?.subscription_status === 'active';
+  const status = data?.subscription_status ?? 'inactive';
+  window.sbSubStatus  = status;
+  window.sbSubEnd     = data?.subscription_end ?? null;
+  window.sbSubscribed = ['active', 'trialing', 'lifetime'].includes(status);
 }
 
 // ── Authenticated fetch for gated picks data ───────────────────────────────
@@ -42,7 +54,7 @@ window.fetchGatedData = async function (file) {
   }
 };
 
-// ── Stripe checkout ────────────────────────────────────────────────────────
+// ── Stripe checkout (5-day free trial) ────────────────────────────────────
 window.startSubscription = async function () {
   if (!window.sbUser) { openModal('signup'); return; }
   const btns = document.querySelectorAll('.subscribe-cta');
@@ -61,24 +73,180 @@ window.startSubscription = async function () {
       window.location.href = url;
     } else {
       alert('Could not start checkout. Please try again.');
-      btns.forEach(b => { b.disabled = false; b.textContent = 'Subscribe — $7.99/mo'; });
+      btns.forEach(b => { b.disabled = false; b.textContent = 'Start Free Trial'; });
     }
   } catch {
     alert('Network error. Please try again.');
-    btns.forEach(b => { b.disabled = false; b.textContent = 'Subscribe — $7.99/mo'; });
+    btns.forEach(b => { b.disabled = false; b.textContent = 'Start Free Trial'; });
   }
 };
+
+// ── Cancel subscription ────────────────────────────────────────────────────
+window.cancelSubscription = async function () {
+  const btn = document.getElementById('cancel-sub-btn');
+  if (btn) { btn.disabled = true; btn.textContent = 'Cancelling…'; }
+  try {
+    const res = await fetch(CANCEL_FN, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${window.sbSession.access_token}` },
+    });
+    const data = await res.json();
+    if (res.ok) {
+      const until = data.access_until
+        ? new Date(data.access_until).toLocaleDateString('en-US', {
+            month: 'short', day: 'numeric', year: 'numeric',
+          })
+        : 'the end of your billing period';
+      const contentEl = document.getElementById('manage-modal-body');
+      if (contentEl) {
+        contentEl.innerHTML = `
+          <div class="modal-success">
+            <div class="success-title">Subscription Cancelled</div>
+            <div class="success-body">
+              Your access continues until <strong>${until}</strong>.<br>
+              You won't be charged again.
+            </div>
+          </div>`;
+      }
+      setTimeout(async () => {
+        await _checkSub();
+        _updateHeader();
+      }, 1500);
+    } else {
+      if (btn) { btn.disabled = false; btn.textContent = 'Cancel Subscription'; }
+      alert(data.error || 'Could not cancel. Please try again.');
+    }
+  } catch {
+    if (btn) { btn.disabled = false; btn.textContent = 'Cancel Subscription'; }
+    alert('Network error. Please try again.');
+  }
+};
+
+// ── Redeem promo code ──────────────────────────────────────────────────────
+window.redeemPromo = async function () {
+  if (!window.sbUser) { openModal('signup'); return; }
+  const input = document.getElementById('promo-code-input');
+  const btn   = document.getElementById('promo-submit-btn');
+  const err   = document.getElementById('promo-error');
+  if (!input || !btn) return;
+
+  const code = input.value.trim();
+  if (!code) {
+    if (err) { err.textContent = 'Please enter a promo code.'; err.style.display = 'block'; }
+    return;
+  }
+
+  btn.disabled = true; btn.textContent = 'Applying…';
+  if (err) err.style.display = 'none';
+
+  try {
+    const res = await fetch(REDEEM_FN, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${window.sbSession.access_token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ code }),
+    });
+    const data = await res.json();
+    if (res.ok) {
+      await _checkSub();
+      _updateHeader();
+      _hidePromoForm();
+      if (typeof window.onAuthChanged === 'function') {
+        window.onAuthChanged(window.sbUser, window.sbSubscribed);
+      }
+    } else {
+      if (err) { err.textContent = data.error || 'Invalid promo code.'; err.style.display = 'block'; }
+      btn.disabled = false; btn.textContent = 'Apply Code';
+    }
+  } catch {
+    if (err) { err.textContent = 'Network error. Please try again.'; err.style.display = 'block'; }
+    btn.disabled = false; btn.textContent = 'Apply Code';
+  }
+};
+
+// ── Manage subscription modal ──────────────────────────────────────────────
+window.openManageModal = function () {
+  const m = document.getElementById('manage-modal');
+  if (!m) return;
+  _renderManageModal();
+  m.style.display = 'flex';
+};
+
+window.closeManageModal = function () {
+  const m = document.getElementById('manage-modal');
+  if (m) m.style.display = 'none';
+};
+
+function _renderManageModal() {
+  const el = document.getElementById('manage-modal-body');
+  if (!el) return;
+
+  const status   = window.sbSubStatus;
+  const subEnd   = window.sbSubEnd;
+  const fmtDate  = (iso) => iso
+    ? new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+    : null;
+
+  let pillClass = 'status-inactive';
+  let pillLabel = 'Inactive';
+  let meta      = '';
+  let showCancel = false;
+
+  if (status === 'lifetime') {
+    pillClass = 'status-lifetime'; pillLabel = 'Lifetime Access';
+    meta = 'You have permanent free access via promo code.';
+  } else if (status === 'trialing') {
+    pillClass = 'status-trial'; pillLabel = 'Free Trial';
+    meta = subEnd ? `Trial ends <strong>${fmtDate(subEnd)}</strong> — card will be charged then.` : 'Trial active.';
+    showCancel = true;
+  } else if (status === 'active') {
+    pillClass = 'status-active'; pillLabel = 'Active';
+    meta = subEnd ? `Renews <strong>${fmtDate(subEnd)}</strong>` : '';
+    showCancel = true;
+  } else if (status === 'past_due') {
+    pillClass = 'status-pastdue'; pillLabel = 'Past Due';
+    meta = 'Payment failed. Please update your payment method.';
+  }
+
+  el.innerHTML = `
+    <div class="manage-status-row">
+      <span class="status-pill ${pillClass}">${pillLabel}</span>
+      <span class="manage-meta">${meta}</span>
+    </div>
+    ${showCancel ? `
+      <div class="manage-cancel-section">
+        <p class="manage-cancel-info">Cancelling ends billing at the current period end — your access remains until then.</p>
+        <button class="cancel-btn" id="cancel-sub-btn" onclick="window.cancelSubscription()">Cancel Subscription</button>
+      </div>` : ''}`;
+}
+
+// ── Promo code form toggle (in paywall) ────────────────────────────────────
+window.showPromoForm = function () {
+  const form = document.getElementById('promo-inline-form');
+  const link = document.getElementById('promo-toggle-link');
+  if (form) form.style.display = 'flex';
+  if (link) link.style.display = 'none';
+};
+
+function _hidePromoForm() {
+  const form = document.getElementById('promo-inline-form');
+  if (form) form.style.display = 'none';
+}
 
 // ── Header auth bar ────────────────────────────────────────────────────────
 function _updateHeader() {
   const loggedOut = document.getElementById('auth-logged-out');
   const loggedIn  = document.getElementById('auth-logged-in');
   const emailEl   = document.getElementById('auth-user-email');
+  const manageBtn = document.getElementById('auth-manage-btn');
   if (!loggedOut || !loggedIn) return;
   if (window.sbUser) {
     loggedOut.style.display = 'none';
     loggedIn.style.display  = 'flex';
     if (emailEl) emailEl.textContent = window.sbUser.email;
+    if (manageBtn) manageBtn.style.display = window.sbSubscribed ? 'inline-block' : 'none';
   } else {
     loggedOut.style.display = 'flex';
     loggedIn.style.display  = 'none';
@@ -88,7 +256,7 @@ function _updateHeader() {
 // ── Auth actions ───────────────────────────────────────────────────────────
 window.sbSignOut = async function () { if (sb) await sb.auth.signOut(); };
 
-// ── Modal (upgrades inline stubs with full tab-switching behaviour) ────────
+// ── Modal ──────────────────────────────────────────────────────────────────
 window.openModal = function (tab) {
   const m = document.getElementById('auth-modal');
   if (!m) return;
@@ -175,6 +343,8 @@ async function _init() {
     window.sbSession    = session;
     window.sbUser       = session?.user ?? null;
     window.sbSubscribed = false;
+    window.sbSubStatus  = 'inactive';
+    window.sbSubEnd     = null;
     if (window.sbUser) await _checkSub();
     _updateHeader();
     if (typeof window.onAuthChanged === 'function') {
@@ -199,6 +369,9 @@ async function _init() {
 document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('auth-modal')?.addEventListener('click', e => {
     if (e.target === document.getElementById('auth-modal')) closeModal();
+  });
+  document.getElementById('manage-modal')?.addEventListener('click', e => {
+    if (e.target === document.getElementById('manage-modal')) closeManageModal();
   });
   document.querySelectorAll('.modal-tab').forEach(t =>
     t.addEventListener('click', () => _tab(t.dataset.tab)));

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -77,24 +77,35 @@ async function loadGatedData() {
 
 function renderPicksPaywall(reason) {
   const isSignin = reason === 'signin';
-  const overlay  = `
+  const promoSection = !isSignin ? `
+    <div class="promo-section">
+      <a id="promo-toggle-link" class="promo-toggle-link" href="#" onclick="event.preventDefault();window.showPromoForm&&window.showPromoForm()">Have a promo code?</a>
+      <div id="promo-inline-form" class="promo-inline-form" style="display:none">
+        <input id="promo-code-input" class="promo-input" type="text" placeholder="Enter code" autocomplete="off" />
+        <button id="promo-submit-btn" class="promo-submit-btn" onclick="window.redeemPromo&&window.redeemPromo()">Apply Code</button>
+        <div id="promo-error" class="promo-error" style="display:none"></div>
+      </div>
+    </div>` : '';
+
+  const overlay = `
     <div class="paywall-overlay">
       <div class="paywall-icon">🔒</div>
       <div class="paywall-title">Today's Picks are for subscribers</div>
       <div class="paywall-desc">
         Get today's moneyline picks with edge, EV, and confidence ratings.<br>
-        Historical track record is always free.
+        5-day free trial, then $7.99/month. Historical track record is always free.
       </div>
       <div class="paywall-actions">
         ${isSignin
           ? `<button class="auth-btn auth-btn-primary subscribe-cta" onclick="openModal('signin')">Sign in</button>
-             <button class="subscribe-cta paywall-sub-btn" onclick="startSubscription()">Subscribe — $7.99/mo</button>`
-          : `<button class="subscribe-cta paywall-sub-btn" onclick="startSubscription()">Subscribe — $7.99/mo</button>`
+             <button class="subscribe-cta paywall-sub-btn" onclick="startSubscription()">Start Free Trial</button>`
+          : `<button class="subscribe-cta paywall-sub-btn" onclick="startSubscription()">Start Free Trial</button>`
         }
       </div>
+      ${promoSection}
     </div>`;
 
-  setHTML('potd-card', `<p style="color:var(--muted);font-style:italic">Subscribe to unlock today's best pick.</p>`);
+  setHTML('potd-card', `<p style="color:var(--muted);font-style:italic">Start your free trial to unlock today's best pick.</p>`);
   setHTML('today-picks', overlay);
 }
 

--- a/supabase/functions/cancel-subscription/index.ts
+++ b/supabase/functions/cancel-subscription/index.ts
@@ -7,8 +7,6 @@ const CORS = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 }
 
-const TRIAL_DAYS = 5
-
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: CORS })
 
@@ -26,27 +24,46 @@ serve(async (req) => {
     )
     if (error || !user) return json({ error: 'Unauthorized' }, 401)
 
-    const stripe  = new Stripe(Deno.env.get('STRIPE_SECRET_KEY')!, {
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('stripe_customer_id, subscription_status')
+      .eq('user_id', user.id)
+      .single()
+
+    if (!profile?.stripe_customer_id) {
+      return json({ error: 'No active subscription found' }, 400)
+    }
+
+    if (profile.subscription_status === 'lifetime') {
+      return json({ error: 'Lifetime access cannot be cancelled' }, 400)
+    }
+
+    const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY')!, {
       apiVersion: '2023-08-16',
       httpClient: Stripe.createFetchHttpClient(),
     })
-    const siteUrl = Deno.env.get('SITE_URL') ?? 'https://localhost'
-    const priceId = Deno.env.get('STRIPE_PRICE_ID')!
 
-    const session = await stripe.checkout.sessions.create({
-      payment_method_types: ['card'],
-      line_items: [{ price: priceId, quantity: 1 }],
-      mode: 'subscription',
-      subscription_data: {
-        trial_period_days: TRIAL_DAYS,
-      },
-      success_url: `${siteUrl}?subscribed=true`,
-      cancel_url:  `${siteUrl}`,
-      customer_email: user.email,
-      metadata: { user_id: user.id },
+    // Find active or trialing subscription
+    let sub: Stripe.Subscription | null = null
+    for (const status of ['active', 'trialing'] as const) {
+      const list = await stripe.subscriptions.list({
+        customer: profile.stripe_customer_id,
+        status,
+        limit: 1,
+      })
+      if (list.data.length > 0) { sub = list.data[0]; break }
+    }
+
+    if (!sub) return json({ error: 'No active subscription found' }, 400)
+
+    const updated = await stripe.subscriptions.update(sub.id, {
+      cancel_at_period_end: true,
     })
 
-    return json({ url: session.url })
+    return json({
+      cancelled: true,
+      access_until: new Date(updated.current_period_end * 1000).toISOString(),
+    })
   } catch (err) {
     return json({ error: err.message }, 500)
   }

--- a/supabase/functions/create-checkout-session/index.ts
+++ b/supabase/functions/create-checkout-session/index.ts
@@ -37,6 +37,7 @@ serve(async (req) => {
       payment_method_types: ['card'],
       line_items: [{ price: priceId, quantity: 1 }],
       mode: 'subscription',
+      allow_promotion_codes: true,
       subscription_data: {
         trial_period_days: TRIAL_DAYS,
       },

--- a/supabase/functions/get-picks-data/index.ts
+++ b/supabase/functions/get-picks-data/index.ts
@@ -33,7 +33,8 @@ serve(async (req) => {
       .eq('user_id', user.id)
       .single()
 
-    if (profile?.subscription_status !== 'active') {
+    const ACTIVE_STATUSES = new Set(['active', 'trialing', 'lifetime'])
+    if (!ACTIVE_STATUSES.has(profile?.subscription_status ?? '')) {
       return json({ error: 'Subscription required' }, 402)
     }
 

--- a/supabase/functions/redeem-promo/index.ts
+++ b/supabase/functions/redeem-promo/index.ts
@@ -1,13 +1,15 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-import Stripe from 'https://esm.sh/stripe@13.2.0?target=deno'
 
 const CORS = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 }
 
-const TRIAL_DAYS = 5
+// Promo code → subscription_status grant
+const PROMO_CODES: Record<string, string> = {
+  'FREE4LIFE': 'lifetime',
+}
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: CORS })
@@ -26,27 +28,32 @@ serve(async (req) => {
     )
     if (error || !user) return json({ error: 'Unauthorized' }, 401)
 
-    const stripe  = new Stripe(Deno.env.get('STRIPE_SECRET_KEY')!, {
-      apiVersion: '2023-08-16',
-      httpClient: Stripe.createFetchHttpClient(),
-    })
-    const siteUrl = Deno.env.get('SITE_URL') ?? 'https://localhost'
-    const priceId = Deno.env.get('STRIPE_PRICE_ID')!
+    const body = await req.json()
+    const code = String(body?.code ?? '').toUpperCase().trim()
+    if (!code) return json({ error: 'Promo code required' }, 400)
 
-    const session = await stripe.checkout.sessions.create({
-      payment_method_types: ['card'],
-      line_items: [{ price: priceId, quantity: 1 }],
-      mode: 'subscription',
-      subscription_data: {
-        trial_period_days: TRIAL_DAYS,
-      },
-      success_url: `${siteUrl}?subscribed=true`,
-      cancel_url:  `${siteUrl}`,
-      customer_email: user.email,
-      metadata: { user_id: user.id },
-    })
+    const grantStatus = PROMO_CODES[code]
+    if (!grantStatus) return json({ error: 'Invalid promo code' }, 400)
 
-    return json({ url: session.url })
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('subscription_status, promo_code')
+      .eq('user_id', user.id)
+      .single()
+
+    if (profile?.subscription_status === 'active') {
+      return json({ error: 'You already have an active paid subscription' }, 400)
+    }
+    if (profile?.promo_code) {
+      return json({ error: 'A promo code has already been applied to this account' }, 400)
+    }
+
+    await supabase.from('profiles').update({
+      subscription_status: grantStatus,
+      promo_code: code,
+    }).eq('user_id', user.id)
+
+    return json({ success: true, status: grantStatus })
   } catch (err) {
     return json({ error: err.message }, 500)
   }

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -3,8 +3,8 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import Stripe from 'https://esm.sh/stripe@13.2.0?target=deno'
 
 serve(async (req) => {
-  const sig    = req.headers.get('stripe-signature')
-  const body   = await req.text()
+  const sig  = req.headers.get('stripe-signature')
+  const body = await req.text()
 
   const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY')!, {
     apiVersion: '2023-08-16',
@@ -25,13 +25,14 @@ serve(async (req) => {
     Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
   )
 
+  // Never overwrite a lifetime promo grant with a Stripe event
   const setStatus = async (customerId: string, status: string, periodEnd?: number) => {
     const { data } = await supabase
       .from('profiles')
-      .select('user_id')
+      .select('user_id, subscription_status')
       .eq('stripe_customer_id', customerId)
       .single()
-    if (data) {
+    if (data && data.subscription_status !== 'lifetime') {
       await supabase.from('profiles').update({
         subscription_status: status,
         subscription_end: periodEnd ? new Date(periodEnd * 1000).toISOString() : null,
@@ -42,21 +43,38 @@ serve(async (req) => {
   switch (event.type) {
     case 'checkout.session.completed': {
       const s = event.data.object as Stripe.Checkout.Session
-      if (s.customer && s.metadata?.user_id) {
-        await supabase.from('profiles').update({
-          stripe_customer_id: s.customer as string,
-          subscription_status: 'active',
-        }).eq('user_id', s.metadata.user_id)
+      if (s.customer && s.metadata?.user_id && s.subscription) {
+        // Retrieve the subscription to check if it's in trial
+        const sub = await stripe.subscriptions.retrieve(s.subscription as string)
+        const status = sub.status === 'trialing' ? 'trialing' : 'active'
+        const { data: profile } = await supabase
+          .from('profiles')
+          .select('subscription_status')
+          .eq('user_id', s.metadata.user_id)
+          .single()
+        if (profile?.subscription_status !== 'lifetime') {
+          await supabase.from('profiles').update({
+            stripe_customer_id: s.customer as string,
+            subscription_status: status,
+            subscription_end: sub.current_period_end
+              ? new Date(sub.current_period_end * 1000).toISOString()
+              : null,
+          }).eq('user_id', s.metadata.user_id)
+        }
       }
       break
     }
     case 'customer.subscription.updated': {
       const sub = event.data.object as Stripe.Subscription
-      await setStatus(
-        sub.customer as string,
-        sub.status === 'active' ? 'active' : 'inactive',
-        sub.current_period_end,
-      )
+      let status: string
+      if (sub.status === 'trialing') {
+        status = 'trialing'
+      } else if (sub.status === 'active') {
+        status = 'active'
+      } else {
+        status = 'inactive'
+      }
+      await setStatus(sub.customer as string, status, sub.current_period_end)
       break
     }
     case 'customer.subscription.deleted': {

--- a/supabase/setup.sql
+++ b/supabase/setup.sql
@@ -37,6 +37,19 @@ CREATE TRIGGER on_auth_user_created
   FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
 
 -- ============================================================
+-- Migration: promo code support (run after initial setup)
+-- ============================================================
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS promo_code TEXT;
+
+-- Valid subscription_status values:
+--   inactive  — no subscription
+--   trialing  — in 5-day free trial (payment method collected, not yet charged)
+--   active    — paid and active
+--   past_due  — payment failed
+--   lifetime  — permanent free access via promo code Free4life
+
+-- ============================================================
 -- After running this SQL:
 --
 -- 1. Go to Storage → New bucket


### PR DESCRIPTION
## Summary
This PR adds comprehensive subscription lifecycle management features, including the ability to cancel subscriptions, redeem promo codes for lifetime access, and view subscription status. It also introduces a 5-day free trial before the first charge.

## Key Changes

**Frontend (JavaScript & HTML)**
- Added `cancelSubscription()` function to handle subscription cancellation via new Stripe webhook
- Added `redeemPromo()` function to validate and apply promo codes (currently supports `FREE4LIFE` for lifetime access)
- Added `openManageModal()` and `closeManageModal()` for subscription management UI
- Added `_renderManageModal()` to display subscription status with contextual messaging based on status (active, trialing, lifetime, past_due, inactive)
- Added promo code form toggle (`showPromoForm()`) in the paywall for unauthenticated users
- Updated subscription status tracking to include `sbSubStatus` and `sbSubEnd` window variables
- Updated `_checkSub()` to fetch and track `subscription_status` and `subscription_end` from profiles
- Updated button text from "Subscribe — $7.99/mo" to "Start Free Trial" throughout the app
- Added "Manage" button in header auth bar (visible only for subscribed users)
- Updated modal notes to reflect 5-day free trial messaging

**Styling (CSS)**
- Added `.manage-body` and `.manage-status-row` styles for subscription status display
- Added `.status-pill` variants (active, trial, lifetime, inactive, past_due) with color-coded badges
- Added `.manage-cancel-section` and `.cancel-btn` styles for cancellation UI
- Added `.promo-section`, `.promo-toggle-link`, `.promo-inline-form`, `.promo-input`, `.promo-submit-btn`, and `.promo-error` styles for promo code form

**Backend (Supabase Functions)**
- Created `cancel-subscription` function: Cancels Stripe subscription at period end, preserving access until then
- Created `redeem-promo` function: Validates promo codes and grants corresponding subscription status (currently `FREE4LIFE` → `lifetime`)
- Updated `create-checkout-session` to include 5-day trial configuration (`TRIAL_DAYS = 5`)
- Updated `stripe-webhook` to:
  - Preserve lifetime promo grants (never overwrite with Stripe events)
  - Track `trialing` status separately from `active`
  - Store `subscription_end` dates for all subscription events
  - Handle trial-to-active transitions correctly

**Database**
- Added `promo_code` column to profiles table for tracking applied promo codes
- Updated subscription_status enum documentation to include `trialing` and `lifetime` states
- Added migration notes for promo code support

## Notable Implementation Details

- Subscription status now has five states: `inactive`, `trialing`, `active`, `past_due`, `lifetime`
- Lifetime promo grants are protected from being overwritten by Stripe webhook events
- Promo code validation prevents duplicate applications and blocks redemption for users with active paid subscriptions
- Cancellation uses Stripe's `cancel_at_period_end` to preserve access through the current billing period
- Trial status is tracked separately to provide appropriate messaging and UI state
- Promo code form is only shown to unauthenticated users in the paywall (not in header)

https://claude.ai/code/session_013wJudmcKRvkUfEXLmmsr8x