### PR TITLE
Fix paywall showing for active subscribers

### DIFF
--- a/docs/js/auth.js
+++ b/docs/js/auth.js
@@ -20,6 +20,11 @@ window.sbSubscribed = false;
 window.sbSubStatus  = 'inactive';  // 'inactive' | 'trialing' | 'active' | 'past_due' | 'lifetime'
 window.sbSubEnd     = null;        // ISO date string of period/trial end
 
+// Resolves once the initial auth + subscription check completes (used to
+// prevent loadGatedData from running before sbSubscribed is known).
+let _resolveAuthReady;
+window.sbAuthReady = new Promise(resolve => { _resolveAuthReady = resolve; });
+
 // ── Subscription check ─────────────────────────────────────────────────────
 async function _checkSub() {
   if (!window.sbUser || !sb) {
@@ -332,7 +337,7 @@ async function _onSignUp(e) {
 
 // ── Init ───────────────────────────────────────────────────────────────────
 async function _init() {
-  if (!sb) { _updateHeader(); return; }
+  if (!sb) { _resolveAuthReady(); _updateHeader(); return; }
   const { data: { session } } = await sb.auth.getSession();
   window.sbSession = session;
   window.sbUser    = session?.user ?? null;
@@ -347,6 +352,8 @@ async function _init() {
     window.sbSubEnd     = null;
     if (window.sbUser) await _checkSub();
     _updateHeader();
+    // Unblock any loadGatedData() calls waiting on the initial auth state.
+    _resolveAuthReady();
     if (typeof window.onAuthChanged === 'function') {
       window.onAuthChanged(window.sbUser, window.sbSubscribed);
     }

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -54,6 +54,10 @@ async function loadGatedData() {
     return;
   }
 
+  // Wait for the initial auth + subscription check to complete before
+  // rendering the paywall, so we never flash it for active subscribers.
+  if (window.sbAuthReady) await window.sbAuthReady;
+
   if (!window.sbUser) {
     renderPicksPaywall('signin');
     return;
@@ -112,6 +116,8 @@ function renderPicksPaywall(reason) {
 function hidePicksPaywall() {
   const el = document.getElementById('today-picks');
   if (el) el.querySelectorAll('.paywall-overlay').forEach(o => o.remove());
+  const banner = document.querySelector('.subscribe-banner');
+  if (banner) banner.style.display = 'none';
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -71,6 +71,8 @@ serve(async (req) => {
         status = 'trialing'
       } else if (sub.status === 'active') {
         status = 'active'
+      } else if (sub.status === 'past_due') {
+        status = 'past_due'
       } else {
         status = 'inactive'
       }


### PR DESCRIPTION
## Summary
- **Race condition fix**: `loadGatedData()` was running before Supabase auth finished initializing, so `window.sbSubscribed` was still `false` for active subscribers. Added `window.sbAuthReady` — a Promise that resolves inside `onAuthStateChange` after the subscription check completes. `loadGatedData()` now awaits it before checking auth state.
- **Subscribe banner never hidden**: The "Unlock today's picks / Start Free Trial" banner in the POTD section was hard-coded HTML and was never removed for subscribers. `hidePicksPaywall()` now also hides `.subscribe-banner` when picks load successfully.
- **Webhook status mapping bug**: `customer.subscription.updated` was mapping Stripe's `past_due` status to `'inactive'`, which could silently strip a subscriber's access on a failed payment cycle. Added explicit `past_due` → `'past_due'` mapping.

https://claude.ai/code/session_01Uw9zRW692A5t9JPqzQPHEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uw9zRW692A5t9JPqzQPHEs)_