### PR TITLE
Hide today's ungraded picks from pick history

### DIFF
--- a/main.py
+++ b/main.py
@@ -301,16 +301,22 @@ def export_dashboard_data():
     (out / "stats.json").write_text(json.dumps(_sanitize_json(stats), indent=2))
 
     history = get_all_predictions()
-    (out / "picks_history.json").write_text(json.dumps(_sanitize_json(history), indent=2))
-
     today_str = date.today().isoformat()
+    # Exclude today's still-ungraded picks from history; they belong in the
+    # "today's picks" section until grading completes.
+    history_for_export = [
+        p for p in history
+        if not (p["date"] == today_str and (p.get("status") or "Pending") == "Pending")
+    ]
+    (out / "picks_history.json").write_text(json.dumps(_sanitize_json(history_for_export), indent=2))
+
     today_picks = [p for p in history if p["date"] == today_str]
     today_ml = [p for p in today_picks if p.get("bet_type", "moneyline") == "moneyline"]
 
     # Upload today's picks to Supabase private storage (subscriber-only).
     # If Supabase is configured, write an empty placeholder to GitHub Pages so
     # the file URL reveals nothing. Otherwise fall back to writing the real data.
-    supabase_ok = upload_picks_to_supabase(today_ml, history)
+    supabase_ok = upload_picks_to_supabase(today_ml, history_for_export)
     if supabase_ok:
         (out / "picks_today.json").write_text("[]")
     else:


### PR DESCRIPTION
## Summary
- Today's picks were appearing in both the "today's picks" section and the pick history while still pending.
- Filter today's `Pending` picks out of the `picks_history.json` export (and the Supabase upload) so each pick only appears in one section at a time.
- Once a pick is graded (status flips off `Pending`), it shows up in pick history on the next export.

## Test plan
- [ ] Run `export_dashboard_data()` mid-day with pending picks: confirm they appear in `picks_today.json` but not `picks_history.json`.
- [ ] After grading completes, confirm graded picks now appear in `picks_history.json`.
- [ ] Verify the same filtering applies to the Supabase upload (`upload_picks_to_supabase`).

https://claude.ai/code/session_01VxVZrdvnvFRSZQ3w5M46zZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VxVZrdvnvFRSZQ3w5M46zZ)_