### PR TITLE
tune: drop unsound features, raise EV threshold, sigmoid-calibrate XGB

### DIFF
--- a/config.py
+++ b/config.py
@@ -33,7 +33,7 @@ DISCORD_WEBHOOK_URL = os.getenv("DISCORD_WEBHOOK_URL", "")
 TRAINING_SEASONS = [2023, 2024, 2025]
 
 # --- EV & Bet Sizing ---
-EV_THRESHOLD  = 0.02  # Minimum edge to place a bet (2%)
+EV_THRESHOLD  = 0.05  # Minimum edge to place a bet (5%)
 KELLY_SCALE   = 13    # Multiplier: translates half-Kelly fraction → intuitive units
 MIN_BET_UNITS = 0.5   # Floor: any qualifying pick bets at least this many units
 MAX_BET_UNITS = 3.0   # Cap: never risk more than this per pick

--- a/features.py
+++ b/features.py
@@ -12,8 +12,6 @@ from data import (
     get_team_hitting_splits,
     _get_pitcher_hand,
     get_park_factor,
-    get_pitcher_days_rest,
-    get_team_rolling_ops,
 )
 
 logger = logging.getLogger(__name__)
@@ -37,12 +35,6 @@ FEATURE_COLUMNS = [
     "away_hit_wrc_plus", "away_hit_ops",
     # Park factor
     "park_factor",
-    # Pitcher rest/fatigue
-    "home_p_days_rest",
-    "away_p_days_rest",
-    # Rolling 10-game team offense
-    "home_team_ops_10",
-    "away_team_ops_10",
 ]
 
 
@@ -104,20 +96,6 @@ def build_game_features(game: dict) -> Optional[dict]:
             "away_hit_ops": away_hitting["ops"],
             "park_factor": get_park_factor(game["home_team"]),
         }
-
-        features["home_p_days_rest"] = get_pitcher_days_rest(
-            game["home_pitcher_id"], game["game_date"]
-        )
-        features["away_p_days_rest"] = get_pitcher_days_rest(
-            game["away_pitcher_id"], game["game_date"]
-        )
-
-        features["home_team_ops_10"] = get_team_rolling_ops(
-            game["home_team_id"], game["game_date"]
-        )
-        features["away_team_ops_10"] = get_team_rolling_ops(
-            game["away_team_id"], game["game_date"]
-        )
 
         return features
 
@@ -242,10 +220,6 @@ def build_training_features(historical_games: pd.DataFrame) -> tuple[pd.DataFram
             "away_hit_wrc_plus": away_hitting["wrc_plus"],
             "away_hit_ops": away_hitting["ops"],
             "park_factor": get_park_factor(game["home_team"]),
-            "home_p_days_rest": 5.0,  # historical games: default rest (API too slow for batch)
-            "away_p_days_rest": 5.0,
-            "home_team_ops_10": 0.735,  # league-average default (~2023-2025 MLB avg OPS)
-            "away_team_ops_10": 0.735,
         }
 
         feature_rows.append(row)

--- a/model.py
+++ b/model.py
@@ -161,11 +161,11 @@ def train_models(X: pd.DataFrame, y: pd.Series, tuned_params: dict | None = None
         xgb_params.update(tuned_params["xgboost"])
         logger.info("Using tuned XGBoost params: %s", tuned_params["xgboost"])
 
-    xgb_eval = CalibratedClassifierCV(XGBClassifier(**xgb_params), cv=5, method="isotonic")
+    xgb_eval = CalibratedClassifierCV(XGBClassifier(**xgb_params), cv=5, method="sigmoid")
     xgb_eval.fit(X_tr, y_tr)
     results["xgboost"] = _evaluate_model("XGBoost", y_te, xgb_eval.predict_proba(X_te)[:, 1])
 
-    xgb_calibrated = CalibratedClassifierCV(XGBClassifier(**xgb_params), cv=5, method="isotonic")
+    xgb_calibrated = CalibratedClassifierCV(XGBClassifier(**xgb_params), cv=5, method="sigmoid")
     xgb_calibrated.fit(X, y)
     joblib.dump(xgb_calibrated, MODEL_DIR / "xgboost.joblib")
     logger.info("XGBoost saved to %s", MODEL_DIR / "xgboost.joblib")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -27,8 +27,8 @@ class TestFeatureColumns:
         )
 
     def test_expected_count(self):
-        # 8 home pitcher + 8 away pitcher + 4 bullpen + 4 hitting + 2 rest + 2 rolling OPS + 1 park = 29
-        assert len(FEATURE_COLUMNS) == 29
+        # 8 home pitcher + 8 away pitcher + 4 bullpen + 4 hitting + 1 park = 25
+        assert len(FEATURE_COLUMNS) == 25
 
     def test_rolling_and_season_both_present(self):
         season_feats = [f for f in FEATURE_COLUMNS if "_season" in f]


### PR DESCRIPTION
## Why

14-day performance review (2026-05-04 → 2026-05-16, 84 graded bets) found three concrete leaks:

| Window | Bets | Win% | Profit | ROI |
|---|---|---|---|---|
| Last 14d | 84 | 48.8% | +5.65u | +9.23% |
| Last 7d | 46 | 45.7% | +1.33u | +3.75% |
| Lifetime | 259 | 45.2% | +18.23u | +4.90% |

Diagnosis:
- **Edge bucket P&L is non-monotonic.** 4–7% edge bucket lost −2.95u over 32 bets (−15% ROI), while 0–4% won at 60% (small sample, noise). The model's stated edge is not predictive of realized ROI.
- **Calibration is over-confident in the 45–60% band**, where most picks live (45–50%: predicted 48.8%, actual 44.1%).
- **Two features are train/predict-inconsistent.** `home_p_days_rest`, `away_p_days_rest`, `home_team_ops_10`, `away_team_ops_10` use hardcoded constants in training (`features.py:245-248`) but real values at inference. The model never learned a relationship — they only inject distribution shift.

## What this changes

1. **`config.py`** — `EV_THRESHOLD` 0.02 → 0.05. Cuts the loss-making 4–7% edge tranche.
2. **`features.py`** — drop the four train/predict-inconsistent features. `FEATURE_COLUMNS` now 25 (was 29).
3. **`model.py`** — XGBoost `CalibratedClassifierCV` method `isotonic` → `sigmoid`. Isotonic over-fits the middle of the curve on moderate-sized training sets; sigmoid should tighten the 45–60% band.
4. **`tests/test_model.py`** — update feature-count assertion.

## ⚠️ Requires retrain before next prediction run

The saved `models/xgboost.joblib` was trained with 29 features + isotonic calibration. The new pipeline produces 25 features. Without a retrain, `predict_win_prob` will fill the 4 dropped columns with `0.0` and predictions will be worse than today.

After merge, run:

```bash
python main.py --retrain
```

## Not included (future work)

From the analysis, these were ranked Tier 2/3 and deferred:

- Recalibrate `compute_confidence` star thresholds from realized ROI (currently non-monotonic: 3★ −17%, 4★ +26%, 5★ +11%)
- Cap bet size for heavy underdogs (`odds ≥ +130` win 39%, below break-even)
- Symmetrize training data (each historical game as two rows, home + away POV) so `is_home` becomes a real signal
- Ensemble xgb + lgbm + lr at predict time

## Test plan

- [x] `pytest tests/` — 118 passed
- [ ] After merge: `python main.py --retrain` and verify `models/training_state.json` updates
- [ ] Monitor next 7 days; expect lower bet volume and higher per-pick edge quality


---
_Generated by [Claude Code](https://claude.ai/code/session_011kmQSSH6Q4LYAJRpYTN963)_