### PR TITLE
Remove signup/paywall and serve today's picks publicly

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -22,7 +22,6 @@
         <div id="header-auth" class="header-auth">
           <div id="auth-logged-out" style="display:flex;gap:8px;align-items:center">
             <button class="auth-btn" onclick="openModal('signin')">Sign in</button>
-            <button class="auth-btn auth-btn-primary" onclick="openModal('signup')">Get access</button>
           </div>
           <div id="auth-logged-in" style="display:none;gap:8px;align-items:center">
             <span id="auth-user-email" class="auth-email"></span>
@@ -88,11 +87,6 @@
           <div id="potd-card" class="potd-card">
             <p style="color:var(--muted)">Loading…</p>
           </div>
-          <div class="subscribe-banner">
-            <div class="sub-title">Unlock today's picks</div>
-            <div class="sub-desc">5-day free trial, then $7.99/month. Cancel anytime.</div>
-            <button class="subscribe-btn subscribe-cta" onclick="startSubscription()">Start Free Trial</button>
-          </div>
         </div>
       </div>
 
@@ -155,11 +149,6 @@
     <div class="modal-content">
       <button class="modal-close" onclick="closeModal()" aria-label="Close">&times;</button>
 
-      <div class="modal-tabs">
-        <button class="modal-tab active" data-tab="signin">Sign in</button>
-        <button class="modal-tab"        data-tab="signup">Create account</button>
-      </div>
-
       <!-- Sign in panel -->
       <div id="signin-panel" class="modal-panel" data-panel="signin" style="display:flex">
         <form id="si-form">
@@ -174,23 +163,6 @@
           <div class="modal-error" style="display:none"></div>
           <button id="si-btn" type="submit" class="modal-submit">Sign in</button>
         </form>
-      </div>
-
-      <!-- Sign up panel -->
-      <div id="signup-panel" class="modal-panel" data-panel="signup" style="display:none">
-        <form id="su-form">
-          <div class="modal-field">
-            <label for="su-email">Email</label>
-            <input id="su-email" type="email" placeholder="you@example.com" required autocomplete="email" />
-          </div>
-          <div class="modal-field">
-            <label for="su-pw">Password</label>
-            <input id="su-pw" type="password" placeholder="Min 8 characters" required minlength="8" autocomplete="new-password" />
-          </div>
-          <div class="modal-error" style="display:none"></div>
-          <button id="su-btn" type="submit" class="modal-submit">Create account</button>
-        </form>
-        <p class="modal-note">After creating your account you'll be sent to checkout to enter a payment method, then start your 5-day free trial. After the trial it's $7.99/month — cancel anytime. By creating an account you agree to our <a href="terms.html" target="_blank" rel="noopener">Terms &amp; Conditions</a> and <a href="privacy.html" target="_blank" rel="noopener">Privacy Policy</a>.</p>
       </div>
     </div>
   </div>
@@ -210,17 +182,9 @@
 
   <!-- Inline stubs: guarantee these globals exist even if auth.js fails to load -->
   <script>
-    function openModal(tab) {
+    function openModal() {
       var m = document.getElementById('auth-modal');
-      if (!m) return;
-      m.style.display = 'flex';
-      var active = tab || 'signin';
-      document.querySelectorAll('.modal-tab').forEach(function(t) {
-        t.classList.toggle('active', t.dataset.tab === active);
-      });
-      document.querySelectorAll('.modal-panel').forEach(function(p) {
-        p.style.display = (p.dataset.panel === active) ? 'flex' : 'none';
-      });
+      if (m) m.style.display = 'flex';
     }
     function closeModal() {
       var m = document.getElementById('auth-modal');
@@ -231,7 +195,6 @@
       var m = document.getElementById('manage-modal');
       if (m) m.style.display = 'none';
     }
-    function startSubscription() { openModal('signup'); }
     function sbSignOut() {}
   </script>
 

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -11,9 +11,10 @@ let filterText  = '';
 // ── Fetch ──────────────────────────────────────────────────────────────────
 async function loadData() {
   try {
-    const [statsRes, historyRes] = await Promise.all([
+    const [statsRes, historyRes, picksRes] = await Promise.all([
       fetch('data/stats.json'),
       fetch('data/picks_history.json'),
+      fetch('data/picks_today.json'),
     ]);
 
     if (!statsRes.ok || !historyRes.ok) {
@@ -23,6 +24,7 @@ async function loadData() {
     statsData  = await statsRes.json();
     const rawHistory = await historyRes.json();
     allHistory = rawHistory.filter(p => !p.bet_type || p.bet_type === 'moneyline');
+    const todayPicks = picksRes.ok ? await picksRes.json() : [];
 
     const loadingEl = document.getElementById('loading');
     const appEl     = document.getElementById('app');
@@ -33,9 +35,8 @@ async function loadData() {
     renderStats();
     renderChart(allHistory, mode);
     renderTable(allHistory);
-
-    // Today's picks and POTD are subscriber-only
-    await loadGatedData();
+    renderPickOfDay(todayPicks);
+    renderTodayPicks(todayPicks);
 
   } catch (err) {
     const loadingEl = document.getElementById('loading');
@@ -43,89 +44,6 @@ async function loadData() {
     showError('Could not load data: ' + err.message);
     console.error(err);
   }
-}
-
-// ── Gated picks (subscribers only) ────────────────────────────────────────
-async function loadGatedData() {
-  // Auth library not loaded (local dev without Supabase) — skip paywall
-  if (typeof window.fetchGatedData !== 'function') {
-    renderPickOfDay([]);
-    renderTodayPicks([]);
-    return;
-  }
-
-  // Wait for the initial auth + subscription check to complete before
-  // rendering the paywall, so we never flash it for active subscribers.
-  if (window.sbAuthReady) await window.sbAuthReady;
-
-  if (!window.sbUser) {
-    renderPicksPaywall('signin');
-    return;
-  }
-
-  if (!window.sbSubscribed) {
-    renderPicksPaywall('subscribe');
-    return;
-  }
-
-  const data = await window.fetchGatedData('picks_today');
-  if (data?.__gated) {
-    // Server confirmed not subscribed (shouldn't reach here normally).
-    renderPicksPaywall('subscribe');
-    return;
-  }
-  if (!data) {
-    // Server error or no picks file yet — user IS subscribed, just no data today.
-    hidePicksPaywall();
-    renderPickOfDay([]);
-    renderTodayPicks([]);
-    return;
-  }
-
-  renderPickOfDay(data);
-  renderTodayPicks(data);
-  hidePicksPaywall();
-}
-
-function renderPicksPaywall(reason) {
-  const isSignin = reason === 'signin';
-  const promoSection = !isSignin ? `
-    <div class="promo-section">
-      <a id="promo-toggle-link" class="promo-toggle-link" href="#" onclick="event.preventDefault();window.showPromoForm&&window.showPromoForm()">Have a promo code?</a>
-      <div id="promo-inline-form" class="promo-inline-form" style="display:none">
-        <input id="promo-code-input" class="promo-input" type="text" placeholder="Enter code" autocomplete="off" />
-        <button id="promo-submit-btn" class="promo-submit-btn" onclick="window.redeemPromo&&window.redeemPromo()">Apply Code</button>
-        <div id="promo-error" class="promo-error" style="display:none"></div>
-      </div>
-    </div>` : '';
-
-  const overlay = `
-    <div class="paywall-overlay">
-      <div class="paywall-icon">🔒</div>
-      <div class="paywall-title">Today's Picks are for subscribers</div>
-      <div class="paywall-desc">
-        Get today's moneyline picks with edge, EV, and confidence ratings.<br>
-        5-day free trial, then $7.99/month. Historical track record is always free.
-      </div>
-      <div class="paywall-actions">
-        ${isSignin
-          ? `<button class="auth-btn auth-btn-primary subscribe-cta" onclick="openModal('signin')">Sign in</button>
-             <button class="subscribe-cta paywall-sub-btn" onclick="startSubscription()">Start Free Trial</button>`
-          : `<button class="subscribe-cta paywall-sub-btn" onclick="startSubscription()">Start Free Trial</button>`
-        }
-      </div>
-      ${promoSection}
-    </div>`;
-
-  setHTML('potd-card', `<p style="color:var(--muted);font-style:italic">Start your free trial to unlock today's best pick.</p>`);
-  setHTML('today-picks', overlay);
-}
-
-function hidePicksPaywall() {
-  const el = document.getElementById('today-picks');
-  if (el) el.querySelectorAll('.paywall-overlay').forEach(o => o.remove());
-  const banner = document.querySelector('.subscribe-banner');
-  if (banner) banner.style.display = 'none';
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -457,9 +375,4 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   loadData();
-
-  // Re-load gated picks whenever login/subscription state changes
-  window.onAuthChanged = async () => {
-    await loadGatedData();
-  };
 });


### PR DESCRIPTION
## Summary
- Picks are no longer behind a paywall — the dashboard fetches `data/picks_today.json` directly alongside stats and history (the file is already published by the daily pipeline).
- Removed the "Get access" header CTA, the Pick-of-the-Day subscribe banner, the paywall overlay, and the signup tab from the auth modal.
- Sign-in stays so existing accounts can still authenticate and use Manage Subscription.

## Test plan
- [ ] Load the dashboard signed-out — today's picks and POTD render without any paywall overlay.
- [ ] Confirm header shows only "Sign in" (no "Get access").
- [ ] Open the auth modal — only the sign-in form is visible, no tabs/signup form.
- [ ] Stats, chart, history table still render as before.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FaaTrguaBa7sYdJyMyRpQ9)_