### PR TITLE
fix: always write picks to picks_today.json and add push retries

### DIFF
--- a/.github/workflows/daily-grade.yml
+++ b/.github/workflows/daily-grade.yml
@@ -34,5 +34,8 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add mlb_bets.db docs/data/
           git diff --cached --quiet || git commit -m "chore: grade predictions $(date -u +%Y-%m-%d)"
-          git pull --rebase -X theirs origin master
-          git push origin master
+          for attempt in 1 2 3 4; do
+            git pull --rebase -X theirs origin master && git push origin master && break
+            echo "Push attempt $attempt failed, retrying in $((attempt * 2))s..."
+            sleep $((attempt * 2))
+          done

--- a/.github/workflows/daily-predict.yml
+++ b/.github/workflows/daily-predict.yml
@@ -72,5 +72,8 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add mlb_bets.db docs/data/
           git diff --cached --quiet || git commit -m "chore: predictions $(date -u +%Y-%m-%d)"
-          git pull --rebase -X theirs origin master
-          git push origin master
+          for attempt in 1 2 3 4; do
+            git pull --rebase -X theirs origin master && git push origin master && break
+            echo "Push attempt $attempt failed, retrying in $((attempt * 2))s..."
+            sleep $((attempt * 2))
+          done

--- a/main.py
+++ b/main.py
@@ -137,7 +137,8 @@ def run_predictions(model_name: str = "xgboost"):
         return
     if not games:
         print("  No games found today (off day or no probable pitchers posted). Exiting.")
-        return  # Not an error — valid off day
+        export_dashboard_data()
+        return
     print(f"        Found {len(games)} games with probable pitchers.")
 
     # Step 2: Load model
@@ -313,14 +314,8 @@ def export_dashboard_data():
     today_picks = [p for p in history if p["date"] == today_str]
     today_ml = [p for p in today_picks if p.get("bet_type", "moneyline") == "moneyline"]
 
-    # Upload today's picks to Supabase private storage (subscriber-only).
-    # If Supabase is configured, write an empty placeholder to GitHub Pages so
-    # the file URL reveals nothing. Otherwise fall back to writing the real data.
-    supabase_ok = upload_picks_to_supabase(today_ml, history_for_export)
-    if supabase_ok:
-        (out / "picks_today.json").write_text("[]")
-    else:
-        (out / "picks_today.json").write_text(json.dumps(_sanitize_json(today_ml), indent=2))
+    upload_picks_to_supabase(today_ml, history_for_export)
+    (out / "picks_today.json").write_text(json.dumps(_sanitize_json(today_ml), indent=2))
 
     if today_picks:
         top = max(today_picks, key=lambda p: p.get("edge") or 0)


### PR DESCRIPTION
## Summary

- **Root cause**: After PR #45 removed the paywall, the dashboard reads `picks_today.json` directly from GitHub Pages. But `export_dashboard_data()` still wrote `[]` to that file whenever the Supabase upload succeeded — so the site never showed picks when running from the GitHub Actions workflow (which has Supabase credentials configured).
- **Secondary fix**: The `run_predictions()` early-return path when no games are found now calls `export_dashboard_data()` so the dashboard stays up-to-date even on off days.
- **Push reliability**: Both `daily-predict` and `daily-grade` workflows now retry the pull-rebase-push sequence up to 4 times with backoff, preventing silent failures when the two jobs race each other.

## Test plan

- [x] All 118 existing tests pass
- [ ] Merge and trigger `daily-predict` workflow manually (`workflow_dispatch`) — verify `docs/data/picks_today.json` contains actual pick data (not `[]`)
- [ ] Verify the dashboard at the GitHub Pages site shows today's picks

https://claude.ai/code/session_01BMVZz5zAff9q2yh2qZbQeb

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMVZz5zAff9q2yh2qZbQeb)_