### PR TITLE
Self-tuning market blend, pick-logic fixes, and dashboard UX upgrades

### DIFF
--- a/.github/workflows/daily-grade.yml
+++ b/.github/workflows/daily-grade.yml
@@ -28,11 +28,12 @@ jobs:
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
         run: python main.py --grade
 
-      - name: Commit updated database and dashboard data
+      - name: Commit updated database, dashboard data, and calibration state
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add mlb_bets.db docs/data/
+          if [ -f models/blend_state.json ]; then git add models/blend_state.json; fi
           git diff --cached --quiet || git commit -m "chore: grade predictions $(date -u +%Y-%m-%d)"
           for attempt in 1 2 3 4; do
             git pull --rebase -X theirs origin master && git push origin master && break

--- a/calibration.py
+++ b/calibration.py
@@ -1,0 +1,193 @@
+"""Self-tuning market blend — learns MARKET_BLEND_WEIGHT from graded outcomes.
+
+The model's raw probability is blended toward the de-vigged market before any
+bet is placed (see evaluate.blend_with_market). The blend weight controls how
+much we trust the market vs. our own model, and the right value can only be
+known empirically. This module closes that loop:
+
+  1. Every prediction day, log the RAW model probability and the no-vig market
+     probability for EVERY game with odds (not just picks — picks-only data is
+     adversely selected and would bias the fit).
+  2. During grading, attach the actual outcome to each logged game.
+  3. After grading, grid-search the blend weight that minimizes log loss of
+     `w * market + (1 - w) * model` on all graded games, and persist it.
+  4. At prediction time, evaluate.py uses the learned weight (bounded, and only
+     once enough graded games exist) instead of the static default.
+
+The result is a feedback loop where the system gets better-calibrated as its
+own track record grows, without ever trusting a small sample: below
+MIN_CALIBRATION_GAMES the static default applies, and the learned weight is
+clamped to [BLEND_WEIGHT_MIN, BLEND_WEIGHT_MAX] so a fluky stretch can never
+swing it to an extreme.
+"""
+
+import json
+import logging
+from datetime import datetime
+from typing import Optional
+
+import numpy as np
+
+from config import MODEL_DIR, MARKET_BLEND_WEIGHT
+
+logger = logging.getLogger(__name__)
+
+BLEND_STATE_PATH = MODEL_DIR / "blend_state.json"
+
+# Don't deviate from the static default until this many graded games exist.
+MIN_CALIBRATION_GAMES = 150
+
+# Hard bounds on the learned weight. The lower bound keeps a healthy amount of
+# market shrinkage even if the model looks great over a stretch; the upper
+# bound stops just short of "pure market" so the model always has a voice.
+BLEND_WEIGHT_MIN = 0.30
+BLEND_WEIGHT_MAX = 0.95
+
+# In-process cache (the daily pipeline calls get_blend_weight per game side).
+_state_cache: Optional[dict] = None
+_state_cache_loaded = False
+
+
+def _load_state() -> Optional[dict]:
+    """Read blend_state.json, caching the result for the process lifetime."""
+    global _state_cache, _state_cache_loaded
+    if not _state_cache_loaded:
+        _state_cache_loaded = True
+        try:
+            _state_cache = json.loads(BLEND_STATE_PATH.read_text())
+        except (FileNotFoundError, ValueError, OSError):
+            _state_cache = None
+    return _state_cache
+
+
+def _invalidate_cache():
+    global _state_cache, _state_cache_loaded
+    _state_cache = None
+    _state_cache_loaded = False
+
+
+def get_blend_state() -> Optional[dict]:
+    """Return the persisted calibration state, or None if not yet learned."""
+    return _load_state()
+
+
+def is_self_tuned() -> bool:
+    """True when the learned blend weight (not the static default) is active."""
+    state = _load_state()
+    return bool(state) and state.get("n_games", 0) >= MIN_CALIBRATION_GAMES
+
+
+def get_blend_weight() -> float:
+    """Active market blend weight for moneyline picks.
+
+    Returns the learned weight when it was fit on a sufficient sample,
+    otherwise the static MARKET_BLEND_WEIGHT default. Always within
+    [BLEND_WEIGHT_MIN, BLEND_WEIGHT_MAX].
+    """
+    state = _load_state()
+    if not state:
+        return MARKET_BLEND_WEIGHT
+    if state.get("n_games", 0) < MIN_CALIBRATION_GAMES:
+        return MARKET_BLEND_WEIGHT
+    weight = state.get("weight")
+    if not isinstance(weight, (int, float)):
+        return MARKET_BLEND_WEIGHT
+    return float(min(BLEND_WEIGHT_MAX, max(BLEND_WEIGHT_MIN, weight)))
+
+
+def log_model_predictions(games_with_odds: list[dict]) -> int:
+    """Persist raw model prob + no-vig market prob for every game with odds.
+
+    Called from the daily prediction run AFTER odds are matched but BEFORE pick
+    filtering, so the log covers the full slate (no adverse selection).
+    Returns the number of games logged.
+    """
+    from database import save_model_log
+    from odds import devig_two_way
+
+    rows = []
+    for g in games_with_odds:
+        model_prob = g.get("model_prob")
+        if model_prob is None or model_prob == 0.5:
+            # 0.5 is the "features unavailable" fallback — not a real prediction,
+            # and including it would drag the fit toward pure market.
+            continue
+        try:
+            home_novig, _ = devig_two_way(g["home_odds"], g["away_odds"])
+        except (KeyError, ZeroDivisionError):
+            continue
+        rows.append({
+            "date": g["game_date"],
+            "home_team": g["home_team"],
+            "away_team": g["away_team"],
+            "raw_model_prob": round(float(model_prob), 4),
+            "market_prob": round(float(home_novig), 4),
+            "home_odds": g.get("home_odds"),
+            "away_odds": g.get("away_odds"),
+            "model_name": g.get("model_name", "xgboost"),
+        })
+
+    if rows:
+        save_model_log(rows)
+    logger.info("Logged %d model predictions for calibration.", len(rows))
+    return len(rows)
+
+
+def _blend_log_loss(weight: float, model: np.ndarray, market: np.ndarray,
+                    y: np.ndarray) -> float:
+    """Log loss of the blended home-win probability at a given weight."""
+    p = weight * market + (1.0 - weight) * model
+    p = np.clip(p, 1e-6, 1.0 - 1e-6)
+    return float(-np.mean(y * np.log(p) + (1 - y) * np.log(1 - p)))
+
+
+def update_blend_weight() -> Optional[dict]:
+    """Refit the blend weight on all graded logged games and persist it.
+
+    Grid-searches weight in [BLEND_WEIGHT_MIN, BLEND_WEIGHT_MAX] (step 0.01)
+    minimizing log loss. Persists the result with diagnostics to
+    blend_state.json. Returns the new state dict, or None when there isn't
+    enough graded data yet.
+    """
+    from database import get_graded_model_log
+
+    rows = get_graded_model_log()
+    n = len(rows)
+    if n < MIN_CALIBRATION_GAMES:
+        logger.info(
+            "Blend calibration: %d graded games (< %d needed) — keeping default weight %.2f.",
+            n, MIN_CALIBRATION_GAMES, MARKET_BLEND_WEIGHT,
+        )
+        return None
+
+    model = np.array([r["raw_model_prob"] for r in rows], dtype=float)
+    market = np.array([r["market_prob"] for r in rows], dtype=float)
+    y = np.array([r["home_win"] for r in rows], dtype=float)
+
+    grid = np.arange(BLEND_WEIGHT_MIN, BLEND_WEIGHT_MAX + 1e-9, 0.01)
+    losses = [_blend_log_loss(w, model, market, y) for w in grid]
+    best_idx = int(np.argmin(losses))
+    best_weight = round(float(grid[best_idx]), 2)
+    best_loss = round(losses[best_idx], 5)
+
+    market_loss = round(_blend_log_loss(1.0, model, market, y), 5)
+    default_loss = round(_blend_log_loss(MARKET_BLEND_WEIGHT, model, market, y), 5)
+
+    state = {
+        "weight": best_weight,
+        "n_games": n,
+        "log_loss": best_loss,
+        "default_weight_log_loss": default_loss,
+        "pure_market_log_loss": market_loss,
+        "updated_at": datetime.utcnow().isoformat() + "Z",
+    }
+    BLEND_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    BLEND_STATE_PATH.write_text(json.dumps(state, indent=2))
+    _invalidate_cache()
+
+    logger.info(
+        "Blend calibration: learned weight %.2f on %d graded games "
+        "(log loss %.5f vs %.5f at default %.2f, %.5f pure market).",
+        best_weight, n, best_loss, default_loss, MARKET_BLEND_WEIGHT, market_loss,
+    )
+    return state

--- a/database.py
+++ b/database.py
@@ -33,6 +33,25 @@ CREATE TABLE IF NOT EXISTS predictions (
     away_pitcher TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+-- Raw model vs market probability for EVERY game with odds (not just picks).
+-- Graded outcomes feed calibration.update_blend_weight(), which learns how
+-- much to shrink the model toward the market. Logging the full slate avoids
+-- the adverse-selection bias a picks-only sample would have.
+CREATE TABLE IF NOT EXISTS model_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    date TEXT NOT NULL,
+    home_team TEXT NOT NULL,
+    away_team TEXT NOT NULL,
+    raw_model_prob REAL NOT NULL,
+    market_prob REAL NOT NULL,
+    home_odds INTEGER,
+    away_odds INTEGER,
+    model_name TEXT,
+    home_win INTEGER,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(date, home_team, away_team)
+);
 """
 
 
@@ -59,6 +78,8 @@ def _migrate_db(conn: sqlite3.Connection):
         ("predicted_away_runs", "REAL"),
         ("total_delta", "REAL"),
         ("confidence", "INTEGER"),
+        # Pre-blend model probability, kept for calibration audits
+        ("raw_model_prob", "REAL"),
     ]
     for col, col_type in new_columns:
         if col not in existing:
@@ -91,12 +112,12 @@ def save_predictions(picks: list[dict], bet_type: str = "moneyline"):
         (date, home_team, away_team, pick, pick_side, model_prob, implied_prob,
          ev, edge, units, odds, status, model_name, home_pitcher, away_pitcher,
          bet_type, listed_total, predicted_total, predicted_home_runs,
-         predicted_away_runs, total_delta, confidence)
+         predicted_away_runs, total_delta, confidence, raw_model_prob)
     VALUES
         (:date, :home_team, :away_team, :pick, :pick_side, :model_prob, :implied_prob,
          :ev, :edge, :units, :odds, 'Pending', :model_name, :home_pitcher, :away_pitcher,
          :bet_type, :listed_total, :predicted_total, :predicted_home_runs,
-         :predicted_away_runs, :total_delta, :confidence)
+         :predicted_away_runs, :total_delta, :confidence, :raw_model_prob)
     """
     normalized = []
     for p in picks:
@@ -108,6 +129,7 @@ def save_predictions(picks: list[dict], bet_type: str = "moneyline"):
         row.setdefault("predicted_away_runs", None)
         row.setdefault("total_delta", None)
         row.setdefault("confidence", None)
+        row.setdefault("raw_model_prob", None)
         normalized.append(row)
 
     with get_connection() as conn:
@@ -184,6 +206,85 @@ def grade_predictions(results: dict[str, dict], for_date: Optional[str] = None):
             graded += 1
 
         logger.info("Graded %d predictions.", graded)
+
+
+def save_model_log(rows: list[dict]):
+    """Upsert raw model vs market probabilities for a slate of games.
+
+    One row per (date, home_team, away_team). Re-running predictions for the
+    same day refreshes the probabilities, but never touches a graded outcome.
+    """
+    if not rows:
+        return
+    sql = """
+    INSERT INTO model_log
+        (date, home_team, away_team, raw_model_prob, market_prob,
+         home_odds, away_odds, model_name)
+    VALUES
+        (:date, :home_team, :away_team, :raw_model_prob, :market_prob,
+         :home_odds, :away_odds, :model_name)
+    ON CONFLICT(date, home_team, away_team) DO UPDATE SET
+        raw_model_prob = excluded.raw_model_prob,
+        market_prob    = excluded.market_prob,
+        home_odds      = excluded.home_odds,
+        away_odds      = excluded.away_odds,
+        model_name     = excluded.model_name
+    WHERE model_log.home_win IS NULL
+    """
+    with get_connection() as conn:
+        conn.executemany(sql, rows)
+    logger.info("Saved %d rows to model_log.", len(rows))
+
+
+def grade_model_log(results: dict[str, dict], for_date: Optional[str] = None):
+    """Attach actual outcomes to ungraded model_log rows.
+
+    Args:
+        results: Dict mapping "AWAY @ HOME" to {"home_score", "away_score", "winner"}.
+        for_date: Only grade rows on this date (YYYY-MM-DD) when given.
+    """
+    with get_connection() as conn:
+        sql = "SELECT id, home_team, away_team FROM model_log WHERE home_win IS NULL"
+        params: list = []
+        if for_date:
+            sql += " AND date = ?"
+            params.append(for_date)
+        pending = conn.execute(sql, params).fetchall()
+
+        graded = 0
+        for row in pending:
+            game_key = f"{row['away_team']} @ {row['home_team']}"
+            result = results.get(game_key)
+            if result is None:
+                continue
+            home_win = 1 if result["winner"] == row["home_team"] else 0
+            conn.execute(
+                "UPDATE model_log SET home_win = ? WHERE id = ?",
+                (home_win, row["id"]),
+            )
+            graded += 1
+        if pending:
+            logger.info("Graded %d / %d model_log rows%s.", graded, len(pending),
+                        f" for {for_date}" if for_date else "")
+
+
+def get_graded_model_log() -> list[dict]:
+    """Return all graded model_log rows for blend-weight calibration."""
+    with get_connection() as conn:
+        rows = conn.execute(
+            """SELECT raw_model_prob, market_prob, home_win
+               FROM model_log WHERE home_win IS NOT NULL"""
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def get_model_log_dates_pending() -> list[str]:
+    """Distinct dates with ungraded model_log rows (for grading backfill)."""
+    with get_connection() as conn:
+        rows = conn.execute(
+            "SELECT DISTINCT date FROM model_log WHERE home_win IS NULL"
+        ).fetchall()
+    return [r["date"] for r in rows]
 
 
 def get_pending_dates() -> list[str]:
@@ -317,7 +418,8 @@ def get_all_predictions() -> list[dict]:
                       model_prob, implied_prob, edge, ev, units, odds,
                       status, result, profit, home_pitcher, away_pitcher,
                       bet_type, listed_total, predicted_total,
-                      predicted_home_runs, predicted_away_runs, total_delta, confidence
+                      predicted_home_runs, predicted_away_runs, total_delta,
+                      confidence, raw_model_prob
                FROM predictions
                ORDER BY date DESC, id DESC""",
             conn,
@@ -325,7 +427,7 @@ def get_all_predictions() -> list[dict]:
     float_cols = [
         "model_prob", "implied_prob", "edge", "ev", "units", "profit",
         "listed_total", "predicted_total", "predicted_home_runs",
-        "predicted_away_runs", "total_delta",
+        "predicted_away_runs", "total_delta", "raw_model_prob",
     ]
     for col in float_cols:
         if col in df.columns:

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -66,6 +66,16 @@ header .inner {
 }
 
 /* ── Toggle ───────────────────────────────────────────────── */
+.toolbar {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.toolbar .toggle-group { margin-bottom: 0; }
+
 .toggle-group {
   display: flex;
   gap: 4px;
@@ -75,6 +85,27 @@ header .inner {
   padding: 3px;
   margin-bottom: 20px;
   width: fit-content;
+}
+
+/* ── Model self-tuning status line ───────────────────────── */
+.model-status {
+  font-size: 12px;
+  color: var(--muted);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 8px 14px;
+  margin-bottom: 20px;
+}
+
+.model-status .tuned { color: var(--green); font-weight: 600; }
+
+/* ── Pick card extras ────────────────────────────────────── */
+.pick-card .pick-pitchers {
+  flex-basis: 100%;
+  color: var(--muted);
+  font-size: 12px;
+  font-style: italic;
 }
 
 .toggle-btn {

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,7 +15,7 @@
   <header>
     <div class="container inner">
       <div class="logo">⚾ <span>Baseball</span> Betting Bot
-        <span style="font-size:12px;font-weight:400;color:var(--muted);margin-left:4px">XGBoost · Moneyline</span>
+        <span style="font-size:12px;font-weight:400;color:var(--muted);margin-left:4px">XGBoost · Self-tuning</span>
       </div>
       <div class="header-right">
         <div id="last-updated" class="last-updated">Loading…</div>
@@ -46,11 +46,22 @@
     <!-- ── Main app (hidden until data loads) ───────────────── -->
     <div id="app" style="display:none">
 
-      <!-- Mode toggle -->
-      <div class="toggle-group">
-        <button class="toggle-btn active" data-mode="ytd">YTD</button>
-        <button class="toggle-btn"        data-mode="all_time">All-Time</button>
+      <!-- Filters: time range + market -->
+      <div class="toolbar">
+        <div class="toggle-group" role="group" aria-label="Time range">
+          <button class="toggle-btn active" data-mode="ytd">YTD</button>
+          <button class="toggle-btn"        data-mode="last30">Last 30d</button>
+          <button class="toggle-btn"        data-mode="all_time">All-Time</button>
+        </div>
+        <div class="toggle-group" role="group" aria-label="Market">
+          <button class="toggle-btn active" data-market="moneyline">Moneyline</button>
+          <button class="toggle-btn"        data-market="totals">Totals</button>
+          <button class="toggle-btn"        data-market="all">All</button>
+        </div>
       </div>
+
+      <!-- Model self-tuning status (populated from stats.json) -->
+      <div id="model-status" class="model-status" style="display:none"></div>
 
       <!-- ── Stat cards ──────────────────────────────────────── -->
       <div class="stats-grid">
@@ -117,11 +128,11 @@
                 <th>Date</th>
                 <th>Game</th>
                 <th>Pick</th>
-                <th>Odds</th>
-                <th>Units</th>
-                <th>Model%</th>
-                <th>Edge</th>
-                <th>Conf</th>
+                <th title="American odds at the time the pick was made (consensus across books)">Odds</th>
+                <th title="Bet size from half-Kelly staking — bigger edge = more units">Units</th>
+                <th title="Model win probability after blending toward the de-vigged market">Model%</th>
+                <th title="Model probability minus the no-vig market probability">Edge</th>
+                <th title="1–5 stars: where the edge sits in the achievable range">Conf</th>
                 <th>Status</th>
                 <th>Profit</th>
               </tr>

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -5,7 +5,8 @@
 let allHistory  = [];
 let statsData   = {};
 let chart       = null;
-let mode        = 'ytd';    // 'ytd' | 'all_time'
+let mode        = 'ytd';        // 'ytd' | 'last30' | 'all_time'
+let market      = 'moneyline';  // 'moneyline' | 'totals' | 'all'
 let filterText  = '';
 
 // ── Fetch ──────────────────────────────────────────────────────────────────
@@ -23,8 +24,7 @@ async function loadData() {
     }
 
     statsData  = await statsRes.json();
-    const rawHistory = await historyRes.json();
-    allHistory = rawHistory.filter(p => !p.bet_type || p.bet_type === 'moneyline');
+    allHistory = await historyRes.json();   // all markets; filtered per-view
     const rawToday = picksRes.ok ? await picksRes.json() : [];
     const rawTotals = totalsRes && totalsRes.ok ? await totalsRes.json() : [];
     // Only show picks that are actually for today (US Eastern). Between runs the
@@ -40,8 +40,9 @@ async function loadData() {
     if (appEl)     appEl.style.display     = 'block';
 
     renderLastUpdated(statsData.last_updated);
+    renderModelStatus(statsData.model);
     renderStats();
-    renderChart(allHistory, mode);
+    renderChart(marketFiltered(allHistory), mode);
     renderTable(allHistory);
     renderPickOfDay(todayPicks);
     renderTodayPicks(todayPicks);
@@ -62,6 +63,27 @@ function $(id) { return document.getElementById(id); }
 // keeps a day's picks visible through that day in the league's reference zone.
 function easternDateStr() {
   return new Date().toLocaleDateString('en-CA', { timeZone: 'America/New_York' });
+}
+
+// Apply the active market filter (moneyline / totals / all) to history rows.
+function marketFiltered(history) {
+  if (market === 'all') return history;
+  if (market === 'totals') return history.filter(p => p.bet_type === 'totals');
+  return history.filter(p => !p.bet_type || p.bet_type === 'moneyline');
+}
+
+// True when a row falls inside the active time range.
+function inTimeRange(p, targetMode) {
+  if (!p.date) return false;
+  if (targetMode === 'ytd') {
+    return p.date.startsWith(String(new Date().getFullYear()));
+  }
+  if (targetMode === 'last30') {
+    const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+      .toISOString().slice(0, 10);
+    return p.date >= cutoff;
+  }
+  return true; // all_time
 }
 
 function setHTML(id, html) {
@@ -113,6 +135,25 @@ function evBadge(ev) {
   return `<span class="${cls}">${ev >= 0 ? '+' : ''}${pct}%</span>`;
 }
 
+// ── Model self-tuning status ───────────────────────────────────────────────
+function renderModelStatus(model) {
+  const el = $('model-status');
+  if (!el || !model || model.blend_weight == null) return;
+  const w = (model.blend_weight * 100).toFixed(0);
+  let text;
+  if (model.self_tuned) {
+    text = `🧠 <span class="tuned">Self-tuned</span>: picks blend ${w}% market /
+            ${100 - w}% model — learned from ${model.calibration_games.toLocaleString()}
+            graded games and re-fit after every grading run.`;
+  } else {
+    const n = model.calibration_games ?? 0;
+    text = `🧠 Self-tuning calibration is collecting data (${n} graded games so far) —
+            picks currently blend ${w}% market / ${100 - w}% model by default.`;
+  }
+  el.innerHTML = text;
+  el.style.display = 'block';
+}
+
 // ── Last updated ───────────────────────────────────────────────────────────
 function renderLastUpdated(iso) {
   if (!iso) return;
@@ -124,12 +165,9 @@ function renderLastUpdated(iso) {
     });
 }
 
-// ── Stats computed from filtered history (moneyline only) ─────────────────
+// ── Stats computed from filtered history ──────────────────────────────────
 function computeStats(history, targetMode) {
-  const ytdYear = String(new Date().getFullYear());
-  const rows = targetMode === 'ytd'
-    ? history.filter(p => p.date && p.date.startsWith(ytdYear))
-    : history;
+  const rows = history.filter(p => inTimeRange(p, targetMode));
   const graded  = rows.filter(p => p.status === 'Win' || p.status === 'Loss');
   const pending = rows.filter(p => p.status === 'Pending').length;
   const wins    = graded.filter(p => p.status === 'Win').length;
@@ -147,9 +185,11 @@ function computeStats(history, targetMode) {
 
 // ── Stats cards ────────────────────────────────────────────────────────────
 function renderStats() {
-  const s     = computeStats(allHistory, mode);
-  const other = computeStats(allHistory, mode === 'ytd' ? 'all_time' : 'ytd');
-  const otherLabel = mode === 'ytd' ? 'All-time' : 'YTD';
+  const rows  = marketFiltered(allHistory);
+  const s     = computeStats(rows, mode);
+  const otherMode  = mode === 'all_time' ? 'ytd' : 'all_time';
+  const other      = computeStats(rows, otherMode);
+  const otherLabel = otherMode === 'ytd' ? 'YTD' : 'All-time';
 
   const wins    = s.wins    ?? 0;
   const losses  = s.losses  ?? 0;
@@ -190,15 +230,22 @@ function renderTodayPicks(picks) {
     const pred  = (p.predicted_home_runs != null && p.predicted_away_runs != null)
       ? `<span class="pick-meta score-pred">Pred: ${fmt(p.predicted_away_runs)} – ${fmt(p.predicted_home_runs)}</span>`
       : '';
+    const model = p.raw_model_prob != null
+      ? `Model: ${fmt(p.raw_model_prob * 100)}% raw → ${fmt(p.model_prob * 100)}% blended`
+      : `Model: ${fmt(p.model_prob * 100)}%`;
+    const pitchers = (p.away_pitcher || p.home_pitcher)
+      ? `<span class="pick-pitchers">${p.away_pitcher || 'TBD'} vs ${p.home_pitcher || 'TBD'}</span>`
+      : '';
     return `
       <div class="pick-card">
         <span class="game-label">${game}</span>
         <span class="pick-team">${p.pick}</span>
         <span class="pick-meta">${fmtOdds(p.odds)} · ${p.units}u</span>
         <span class="pick-meta">${edge} · EV: ${ev}</span>
-        <span class="pick-meta">Model: ${fmt(p.model_prob * 100)}% · Implied: ${fmt(p.implied_prob * 100)}%</span>
+        <span class="pick-meta" title="Raw model probability, then after shrinking toward the no-vig market">${model} · Implied: ${fmt(p.implied_prob * 100)}%</span>
         ${pred}
         <div class="pick-badges">${conf}${statusBadge(p.status)}</div>
+        ${pitchers}
       </div>`;
   }).join(''));
 }
@@ -219,6 +266,9 @@ function renderTodayTotals(picks) {
     const model = p.predicted_total != null
       ? `<span class="pick-meta score-pred">Model total: ${fmt(p.predicted_total)}</span>`
       : '';
+    const pitchers = (p.away_pitcher || p.home_pitcher)
+      ? `<span class="pick-pitchers">${p.away_pitcher || 'TBD'} vs ${p.home_pitcher || 'TBD'}</span>`
+      : '';
     return `
       <div class="pick-card">
         <span class="game-label">${game}</span>
@@ -228,18 +278,15 @@ function renderTodayTotals(picks) {
         <span class="pick-meta">Model: ${fmt(p.model_prob * 100)}% · Implied: ${fmt(p.implied_prob * 100)}%</span>
         ${model}
         <div class="pick-badges">${conf}${statusBadge(p.status)}</div>
+        ${pitchers}
       </div>`;
   }).join(''));
 }
 
 // ── Cumulative P&L chart ───────────────────────────────────────────────────
 function renderChart(history, currentMode) {
-  const ytdYear = new Date().getFullYear();
-
-  let graded = history.filter(p => p.status === 'Win' || p.status === 'Loss');
-  if (currentMode === 'ytd') {
-    graded = graded.filter(p => p.date && p.date.startsWith(String(ytdYear)));
-  }
+  let graded = history.filter(p =>
+    (p.status === 'Win' || p.status === 'Loss') && inTimeRange(p, currentMode));
   graded = [...graded].sort((a, b) => a.date.localeCompare(b.date));
 
   let cumulative = 0;
@@ -322,12 +369,7 @@ function renderChart(history, currentMode) {
 
 // ── History table ──────────────────────────────────────────────────────────
 function renderTable(history) {
-  const ytdYear = String(new Date().getFullYear());
-  let rows = history;
-
-  if (mode === 'ytd') {
-    rows = rows.filter(p => p.date && p.date.startsWith(ytdYear));
-  }
+  let rows = marketFiltered(history).filter(p => inTimeRange(p, mode));
 
   if (filterText) {
     const q = filterText.toLowerCase();
@@ -347,11 +389,14 @@ function renderTable(history) {
 
   setHTML('history-tbody', rows.map(p => {
     const game = `${p.away_team} @ ${p.home_team}`;
+    const pickLabel = (p.bet_type === 'totals' && p.listed_total != null)
+      ? `${p.pick} ${fmt(p.listed_total)}`
+      : (p.pick ?? '—');
     return `
       <tr class="${rowClass(p.status)}">
         <td>${p.date ?? '—'}</td>
         <td>${game}</td>
-        <td style="font-weight:600">${p.pick ?? '—'}</td>
+        <td style="font-weight:600">${pickLabel}</td>
         <td>${fmtOdds(p.odds)}</td>
         <td>${p.units ?? '—'}u</td>
         <td>${p.model_prob != null ? fmt(p.model_prob * 100) + '%' : '—'}</td>
@@ -393,21 +438,36 @@ function showError(msg) {
   if (text)   text.textContent = msg;
 }
 
-// ── Toggle (YTD / All-Time) ────────────────────────────────────────────────
+// ── Toggles (time range + market) ──────────────────────────────────────────
+function rerenderFiltered() {
+  renderStats();
+  renderChart(marketFiltered(allHistory), mode);
+  renderTable(allHistory);
+}
+
 function setMode(newMode) {
   mode = newMode;
-  document.querySelectorAll('.toggle-btn').forEach(btn => {
+  document.querySelectorAll('.toggle-btn[data-mode]').forEach(btn => {
     btn.classList.toggle('active', btn.dataset.mode === mode);
   });
-  renderStats();
-  renderChart(allHistory, mode);
-  renderTable(allHistory);
+  rerenderFiltered();
+}
+
+function setMarket(newMarket) {
+  market = newMarket;
+  document.querySelectorAll('.toggle-btn[data-market]').forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.market === market);
+  });
+  rerenderFiltered();
 }
 
 // ── Init ───────────────────────────────────────────────────────────────────
 document.addEventListener('DOMContentLoaded', () => {
-  document.querySelectorAll('.toggle-btn').forEach(btn => {
+  document.querySelectorAll('.toggle-btn[data-mode]').forEach(btn => {
     btn.addEventListener('click', () => setMode(btn.dataset.mode));
+  });
+  document.querySelectorAll('.toggle-btn[data-market]').forEach(btn => {
+    btn.addEventListener('click', () => setMarket(btn.dataset.market));
   });
 
   const searchInput = document.getElementById('table-search');

--- a/evaluate.py
+++ b/evaluate.py
@@ -14,6 +14,7 @@ from config import (
     TOTALS_MAX_DISAGREEMENT,
 )
 from odds import american_to_implied_prob, american_to_decimal, devig_two_way
+import calibration
 
 logger = logging.getLogger(__name__)
 
@@ -55,9 +56,9 @@ def size_bet(model_prob: float, american_odds: int) -> float:
     Kelly fraction = edge / (decimal_odds - 1)
     Half-Kelly = Kelly * 0.5  (reduces variance while preserving growth)
 
-    Result is capped at 3.0 units. Minimum is the raw half-Kelly value
-    (no artificial floor) so small-edge bets are sized proportionally small.
-    Returned as a float (e.g., 0.3u or 1.5u).
+    The scaled half-Kelly stake is clamped to [MIN_BET_UNITS, MAX_BET_UNITS]:
+    any qualifying pick risks at least the floor, and never more than the cap.
+    Returned as a float (e.g., 0.5u or 1.5u).
 
     Args:
         model_prob: Model's predicted win probability for this side.
@@ -74,7 +75,7 @@ def size_bet(model_prob: float, american_odds: int) -> float:
 
 
 def blend_with_market(model_prob: float, no_vig_prob: float,
-                      weight: float = MARKET_BLEND_WEIGHT) -> float:
+                      weight: float | None = None) -> float:
     """Shrink the model probability toward the de-vigged market consensus.
 
     blended = weight * market + (1 - weight) * model
@@ -82,7 +83,13 @@ def blend_with_market(model_prob: float, no_vig_prob: float,
     A higher `weight` trusts the (sharp) market more. This is the primary
     defense against adverse selection: the raw model overrates the side it
     picks, so betting its un-shrunk probability systematically loses.
+
+    When `weight` is None the self-tuned weight is used — learned weekly from
+    the model's own graded predictions (see calibration.py), falling back to
+    the static MARKET_BLEND_WEIGHT until enough games have been graded.
     """
+    if weight is None:
+        weight = calibration.get_blend_weight()
     return weight * no_vig_prob + (1.0 - weight) * model_prob
 
 
@@ -109,6 +116,7 @@ def filter_positive_ev(games_with_predictions: list[dict]) -> list[dict]:
         List of +EV pick dicts ready for database storage.
     """
     picks = []
+    blend_weight = calibration.get_blend_weight()
 
     for game in games_with_predictions:
         model_prob_home = game["model_prob"]
@@ -117,8 +125,8 @@ def filter_positive_ev(games_with_predictions: list[dict]) -> list[dict]:
         # De-vig the two-way market into true probabilities (sum to 1.0).
         home_novig, away_novig = devig_two_way(game["home_odds"], game["away_odds"])
 
-        # Blend model toward the sharp market.
-        blended_home = blend_with_market(model_prob_home, home_novig)
+        # Blend model toward the sharp market (weight is self-tuned, see calibration.py).
+        blended_home = blend_with_market(model_prob_home, home_novig, weight=blend_weight)
         blended_away = 1.0 - blended_home  # internally consistent with blended_home
 
         # Check home team bet
@@ -134,6 +142,7 @@ def filter_positive_ev(games_with_predictions: list[dict]) -> list[dict]:
                 "pick": game["home_team"],
                 "pick_side": "Home",
                 "model_prob": round(blended_home, 4),
+                "raw_model_prob": round(model_prob_home, 4),
                 "implied_prob": round(home_novig, 4),
                 "ev": home_ev,
                 "edge": home_edge,
@@ -157,6 +166,7 @@ def filter_positive_ev(games_with_predictions: list[dict]) -> list[dict]:
                 "pick": game["away_team"],
                 "pick_side": "Away",
                 "model_prob": round(blended_away, 4),
+                "raw_model_prob": round(model_prob_away, 4),
                 "implied_prob": round(away_novig, 4),
                 "ev": away_ev,
                 "edge": away_edge,
@@ -211,7 +221,10 @@ def filter_totals_ev(games_with_odds: list[dict]) -> list[dict]:
         model_under = 1.0 - model_over
 
         over_novig, under_novig = devig_two_way(over_odds, under_odds)
-        blended_over = blend_with_market(model_over, over_novig)
+        # Totals use the static blend weight: the self-tuned weight is learned
+        # from the moneyline classifier's track record and doesn't transfer to
+        # the analytical score model.
+        blended_over = blend_with_market(model_over, over_novig, weight=MARKET_BLEND_WEIGHT)
         blended_under = 1.0 - blended_over
 
         delta = round(predicted_total - line, 2)
@@ -240,6 +253,7 @@ def filter_totals_ev(games_with_odds: list[dict]) -> list[dict]:
                 "pick": "Over",
                 "pick_side": "Over",
                 "model_prob": round(blended_over, 4),
+                "raw_model_prob": round(model_over, 4),
                 "implied_prob": round(over_novig, 4),
                 "ev": over_ev,
                 "edge": over_edge,
@@ -257,6 +271,7 @@ def filter_totals_ev(games_with_odds: list[dict]) -> list[dict]:
                 "pick": "Under",
                 "pick_side": "Under",
                 "model_prob": round(blended_under, 4),
+                "raw_model_prob": round(model_under, 4),
                 "implied_prob": round(under_novig, 4),
                 "ev": under_ev,
                 "edge": under_edge,
@@ -269,24 +284,37 @@ def filter_totals_ev(games_with_odds: list[dict]) -> list[dict]:
     return picks
 
 
-def compute_confidence(edge: float, ev: float) -> int:
-    """Return a 1–5 star rating based on edge and EV thresholds.
+def compute_confidence(edge: float, ev: float,
+                       max_disagreement: float = MAX_RAW_DISAGREEMENT,
+                       weight: float | None = None) -> int:
+    """Return a 1–5 star rating from where the edge sits in the achievable band.
 
-    5 stars: edge >= 10% AND ev >= 0.20
-    4 stars: edge >= 7%  AND ev >= 0.12
-    3 stars: edge >= 5%  AND ev >= 0.08
-    2 stars: edge >= 3%  AND ev >= 0.04
-    1 star:  anything that cleared the EV threshold
+    Because every pick's probability is blended toward the market, the maximum
+    achievable edge is (1 - blend_weight) * max_disagreement — e.g. with a 0.5
+    weight and the 0.15 moneyline cap, no pick can ever exceed a 7.5% edge.
+    Fixed thresholds like "5 stars at 10% edge" were therefore unreachable and
+    every pick clustered at 2–3 stars. Instead, the band between EV_THRESHOLD
+    (the minimum edge to bet at all) and that achievable maximum is split into
+    five equal tiers, so the stars adapt automatically when the self-tuned
+    blend weight changes.
+
+    Args:
+        edge: The pick's blended edge over the no-vig market.
+        ev: The pick's expected value (kept for API compatibility / future use).
+        max_disagreement: The raw-disagreement cap for this market type
+            (MAX_RAW_DISAGREEMENT for moneyline, TOTALS_MAX_DISAGREEMENT for O/U).
+        weight: Blend weight used for this market; None = self-tuned moneyline weight.
     """
-    if edge >= 0.10 and ev >= 0.20:
-        return 5
-    if edge >= 0.07 and ev >= 0.12:
-        return 4
-    if edge >= 0.05 and ev >= 0.08:
-        return 3
-    if edge >= 0.03 and ev >= 0.04:
-        return 2
-    return 1
+    if weight is None:
+        weight = calibration.get_blend_weight()
+    max_edge = (1.0 - weight) * max_disagreement
+    span = max_edge - EV_THRESHOLD
+    if span <= 0:
+        return 1
+    frac = (edge - EV_THRESHOLD) / span
+    if frac <= 0:
+        return 1
+    return min(5, 1 + int(frac * 5))
 
 
 def format_picks(picks: list[dict]) -> str:

--- a/main.py
+++ b/main.py
@@ -26,6 +26,14 @@ from model import load_model, predict_win_prob
 from odds import fetch_live_odds, match_odds_to_games
 from evaluate import filter_positive_ev, filter_totals_ev, format_picks, format_stats, compute_confidence
 from score import predict_game_scores
+from calibration import (
+    log_model_predictions,
+    update_blend_weight,
+    get_blend_state,
+    get_blend_weight,
+    is_self_tuned,
+)
+from config import MARKET_BLEND_WEIGHT, TOTALS_MAX_DISAGREEMENT
 
 logger = logging.getLogger(__name__)
 
@@ -277,8 +285,17 @@ def run_predictions(model_name: str = "xgboost", force: bool = False):
         return
     print(f"        Matched odds for {len(games_with_odds)} games.")
 
+    # Log raw model vs market probability for the FULL slate. Graded outcomes
+    # feed the self-tuning blend weight (see calibration.py).
+    try:
+        log_model_predictions(games_with_odds)
+    except Exception as e:
+        logger.warning("Calibration logging failed (non-fatal): %s", e)
+
     # Step 5: Calculate EV, attach confidence, and filter picks
     print("\n  [5/5] Calculating EV and filtering picks...")
+    print(f"        Market blend weight: {get_blend_weight():.2f} "
+          f"({'self-tuned' if is_self_tuned() else 'default'})")
     ml_picks = filter_positive_ev(games_with_odds)
     for p in ml_picks:
         p["confidence"] = compute_confidence(p["edge"], p["ev"])
@@ -293,7 +310,11 @@ def run_predictions(model_name: str = "xgboost", force: bool = False):
     # Totals (Over/Under) picks from the score model + posted O/U lines.
     totals_picks = filter_totals_ev(games_with_odds)
     for p in totals_picks:
-        p["confidence"] = compute_confidence(p["edge"], p["ev"])
+        p["confidence"] = compute_confidence(
+            p["edge"], p["ev"],
+            max_disagreement=TOTALS_MAX_DISAGREEMENT,
+            weight=MARKET_BLEND_WEIGHT,
+        )
 
     # Display picks
     print(format_picks(ml_picks))
@@ -337,11 +358,12 @@ def run_grading():
     print(f"  MLB BETTING MODEL — Grading ({date.today()})")
     print(f"{'='*60}")
 
-    from database import get_pending_dates
+    from database import get_pending_dates, get_model_log_dates_pending, grade_model_log
 
     yesterday = (date.today() - timedelta(days=1)).isoformat()
     pending_dates = get_pending_dates()
-    dates_to_grade = sorted(set(pending_dates) | {yesterday})
+    pending_log_dates = get_model_log_dates_pending()
+    dates_to_grade = sorted(set(pending_dates) | set(pending_log_dates) | {yesterday})
     print(f"\n  Grading dates: {', '.join(dates_to_grade)}")
 
     graded_any = False
@@ -356,10 +378,23 @@ def run_grading():
             continue
         print(f"  {d}: grading against {len(results)} final games.")
         grade_predictions(results, for_date=d)
+        grade_model_log(results, for_date=d)
         graded_any = True
 
     if not graded_any:
         print("  Nothing graded this run.")
+
+    # Self-tuning step: refit the market blend weight on all graded games.
+    try:
+        state = update_blend_weight()
+        if state:
+            print(f"\n  Blend weight self-tuned to {state['weight']:.2f} "
+                  f"on {state['n_games']} graded games "
+                  f"(log loss {state['log_loss']:.5f}).")
+        else:
+            print("\n  Blend weight: not enough graded games yet — using default.")
+    except Exception as e:
+        logger.warning("Blend weight update failed (non-fatal): %s", e)
 
     # Show updated stats
     show_stats()
@@ -404,9 +439,16 @@ def export_dashboard_data():
     out.mkdir(parents=True, exist_ok=True)
 
     ytd_since = f"{date.today().year}-01-01"
+    blend_state = get_blend_state()
     stats = {
         "ytd": {**get_roi_stats(since=ytd_since), "since": ytd_since},
         "all_time": get_roi_stats(),
+        "model": {
+            "blend_weight": get_blend_weight(),
+            "self_tuned": is_self_tuned(),
+            "calibration_games": (blend_state or {}).get("n_games", 0),
+            "calibration_updated": (blend_state or {}).get("updated_at"),
+        },
         "last_updated": datetime.utcnow().isoformat() + "Z",
     }
     (out / "stats.json").write_text(json.dumps(_sanitize_json(stats), indent=2))

--- a/score.py
+++ b/score.py
@@ -10,7 +10,8 @@ def predict_game_scores(features: dict) -> dict:
     """Estimate expected runs for home and away teams from game features.
 
     Uses away starter xFIP and home team OPS to project home runs, and vice
-    versa for away runs.  Park factor is applied to the home team's offense.
+    versa for away runs.  The park factor applies to BOTH teams — they hit in
+    the same stadium — so e.g. Coors boosts the visitors' scoring too.
     Returns keys: predicted_home_score, predicted_away_score, predicted_total.
     """
     home_xfip = features.get("away_p_xFIP_season", _LEAGUE_AVG_ERA) or _LEAGUE_AVG_ERA
@@ -30,7 +31,8 @@ def predict_game_scores(features: dict) -> dict:
     away_runs = round(
         _BASE_RUNS
         * (away_xfip / _LEAGUE_AVG_ERA)
-        * (away_ops  / _LEAGUE_AVG_OPS),
+        * (away_ops  / _LEAGUE_AVG_OPS)
+        * park,
         2,
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,5 +3,22 @@
 import sys
 import os
 
+import pytest
+
 # Ensure the project root is on the path so tests can import project modules
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture(autouse=True)
+def _default_blend_weight(monkeypatch):
+    """Pin the market blend weight to the static default.
+
+    The weight is self-tuned from graded outcomes (models/blend_state.json),
+    which would make pick-filtering assertions depend on whatever state file
+    happens to be checked out. Tests that exercise the tuning itself override
+    this explicitly.
+    """
+    import calibration
+    from config import MARKET_BLEND_WEIGHT
+    monkeypatch.setattr(calibration, "get_blend_weight", lambda: MARKET_BLEND_WEIGHT)
+    monkeypatch.setattr(calibration, "is_self_tuned", lambda: False)

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,0 +1,212 @@
+"""Tests for calibration.py — the self-tuning market blend loop."""
+
+import json
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+import calibration
+import database
+from config import MARKET_BLEND_WEIGHT
+
+# Bound at import time, BEFORE the autouse conftest fixture stubs them out —
+# these tests exercise the real implementations.
+_REAL_GET_BLEND_WEIGHT = calibration.get_blend_weight
+_REAL_IS_SELF_TUNED = calibration.is_self_tuned
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    """Temporary database with the full schema (predictions + model_log)."""
+    db_file = tmp_path / "test_bets.db"
+    with patch("database.DB_PATH", db_file):
+        database.init_db()
+        yield db_file
+
+
+@pytest.fixture
+def tmp_blend_state(tmp_path, monkeypatch):
+    """Point BLEND_STATE_PATH at a temp file, restore the real (unstubbed)
+    weight functions, and reset the in-process cache."""
+    monkeypatch.setattr(calibration, "get_blend_weight", _REAL_GET_BLEND_WEIGHT)
+    monkeypatch.setattr(calibration, "is_self_tuned", _REAL_IS_SELF_TUNED)
+    state_path = tmp_path / "blend_state.json"
+    with patch("calibration.BLEND_STATE_PATH", state_path):
+        calibration._invalidate_cache()
+        yield state_path
+    calibration._invalidate_cache()
+
+
+def _log_row(date="2026-06-01", home="NYY", away="BOS",
+             model=0.60, market=0.55, home_win=None):
+    return {
+        "date": date, "home_team": home, "away_team": away,
+        "raw_model_prob": model, "market_prob": market,
+        "home_odds": -120, "away_odds": 100, "model_name": "xgboost",
+        "home_win": home_win,
+    }
+
+
+# ---------------------------------------------------------------------------
+# model_log storage and grading
+# ---------------------------------------------------------------------------
+
+class TestModelLog:
+    def test_save_and_grade(self, tmp_db):
+        row = _log_row()
+        database.save_model_log([{k: v for k, v in row.items() if k != "home_win"}])
+
+        database.grade_model_log(
+            {"BOS @ NYY": {"home_score": 5, "away_score": 3, "winner": "NYY"}},
+            for_date="2026-06-01",
+        )
+        graded = database.get_graded_model_log()
+        assert len(graded) == 1
+        assert graded[0]["home_win"] == 1
+        assert graded[0]["raw_model_prob"] == pytest.approx(0.60)
+
+    def test_upsert_replaces_ungraded_only(self, tmp_db):
+        base = {k: v for k, v in _log_row(model=0.60).items() if k != "home_win"}
+        database.save_model_log([base])
+        # Re-run with fresher odds/prob — should overwrite while ungraded
+        database.save_model_log([{**base, "raw_model_prob": 0.62}])
+
+        database.grade_model_log(
+            {"BOS @ NYY": {"home_score": 2, "away_score": 7, "winner": "BOS"}},
+            for_date="2026-06-01",
+        )
+        graded = database.get_graded_model_log()
+        assert graded[0]["raw_model_prob"] == pytest.approx(0.62)
+        assert graded[0]["home_win"] == 0
+
+        # A later save must NOT clobber a graded row
+        database.save_model_log([{**base, "raw_model_prob": 0.99}])
+        graded = database.get_graded_model_log()
+        assert graded[0]["raw_model_prob"] == pytest.approx(0.62)
+
+    def test_pending_dates(self, tmp_db):
+        database.save_model_log([
+            {k: v for k, v in _log_row(date="2026-06-01").items() if k != "home_win"},
+            {k: v for k, v in _log_row(date="2026-06-02", home="LAD", away="SF").items()
+             if k != "home_win"},
+        ])
+        assert sorted(database.get_model_log_dates_pending()) == ["2026-06-01", "2026-06-02"]
+
+
+# ---------------------------------------------------------------------------
+# log_model_predictions
+# ---------------------------------------------------------------------------
+
+class TestLogModelPredictions:
+    def test_logs_full_slate_and_skips_fallback_probs(self, tmp_db):
+        games = [
+            {"game_date": "2026-06-01", "home_team": "NYY", "away_team": "BOS",
+             "model_prob": 0.61, "home_odds": -130, "away_odds": 110},
+            # 0.5 is the "features unavailable" fallback — must be excluded
+            {"game_date": "2026-06-01", "home_team": "LAD", "away_team": "SF",
+             "model_prob": 0.5, "home_odds": -150, "away_odds": 130},
+        ]
+        n = calibration.log_model_predictions(games)
+        assert n == 1
+
+    def test_market_prob_is_devigged(self, tmp_db):
+        games = [{"game_date": "2026-06-01", "home_team": "NYY", "away_team": "BOS",
+                  "model_prob": 0.61, "home_odds": -110, "away_odds": -110}]
+        calibration.log_model_predictions(games)
+        with database.get_connection() as conn:
+            row = conn.execute("SELECT market_prob FROM model_log").fetchone()
+        # Symmetric -110/-110 de-vigs to exactly 0.5
+        assert row["market_prob"] == pytest.approx(0.5, abs=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# get_blend_weight / update_blend_weight
+# ---------------------------------------------------------------------------
+
+class TestBlendWeight:
+    def test_default_without_state(self, tmp_blend_state):
+        assert calibration.get_blend_weight() == MARKET_BLEND_WEIGHT
+        assert calibration.is_self_tuned() is False
+
+    def test_default_below_min_sample(self, tmp_blend_state):
+        tmp_blend_state.write_text(json.dumps({"weight": 0.9, "n_games": 10}))
+        calibration._invalidate_cache()
+        assert calibration.get_blend_weight() == MARKET_BLEND_WEIGHT
+
+    def test_learned_weight_used_and_clamped(self, tmp_blend_state):
+        tmp_blend_state.write_text(json.dumps(
+            {"weight": 0.99, "n_games": calibration.MIN_CALIBRATION_GAMES}))
+        calibration._invalidate_cache()
+        assert calibration.get_blend_weight() == calibration.BLEND_WEIGHT_MAX
+        assert calibration.is_self_tuned() is True
+
+    def test_update_requires_min_games(self, tmp_db, tmp_blend_state):
+        database.save_model_log(
+            [{k: v for k, v in _log_row().items() if k != "home_win"}])
+        assert calibration.update_blend_weight() is None
+        assert not tmp_blend_state.exists()
+
+    def test_update_learns_market_trust_when_model_is_noise(self, tmp_db, tmp_blend_state):
+        # Construct a sample where the market is well-calibrated and the model
+        # is pure noise: the optimal weight must land at the upper bound.
+        rng = np.random.default_rng(42)
+        n = 1000
+        market = rng.uniform(0.35, 0.65, n)
+        outcomes = (rng.uniform(0, 1, n) < market).astype(int)
+        model = rng.uniform(0.3, 0.7, n)  # uninformative
+
+        rows = []
+        for i in range(n):
+            rows.append({
+                "date": f"2026-05-{(i % 28) + 1:02d}", "home_team": f"T{i}",
+                "away_team": f"U{i}", "raw_model_prob": float(model[i]),
+                "market_prob": float(market[i]), "home_odds": -110,
+                "away_odds": -110, "model_name": "xgboost",
+            })
+        database.save_model_log(rows)
+        with database.get_connection() as conn:
+            for i, out in enumerate(outcomes):
+                conn.execute(
+                    "UPDATE model_log SET home_win = ? WHERE home_team = ?",
+                    (int(out), f"T{i}"),
+                )
+
+        state = calibration.update_blend_weight()
+        assert state is not None
+        assert state["n_games"] == n
+        assert state["weight"] >= 0.80  # trusts the market heavily
+        assert state["log_loss"] <= state["default_weight_log_loss"]
+        # And the persisted state now drives get_blend_weight
+        assert calibration.get_blend_weight() == pytest.approx(
+            min(calibration.BLEND_WEIGHT_MAX, max(calibration.BLEND_WEIGHT_MIN, state["weight"])))
+
+    def test_update_keeps_model_voice_when_model_is_better(self, tmp_db, tmp_blend_state):
+        # Model perfectly calibrated, market biased: optimal weight is low.
+        rng = np.random.default_rng(7)
+        n = 400
+        model = rng.uniform(0.35, 0.65, n)
+        outcomes = (rng.uniform(0, 1, n) < model).astype(int)
+        market = np.clip(model + 0.12, 0.01, 0.99)  # systematically biased
+
+        rows = []
+        for i in range(n):
+            rows.append({
+                "date": f"2026-05-{(i % 28) + 1:02d}", "home_team": f"T{i}",
+                "away_team": f"U{i}", "raw_model_prob": float(model[i]),
+                "market_prob": float(market[i]), "home_odds": -110,
+                "away_odds": -110, "model_name": "xgboost",
+            })
+        database.save_model_log(rows)
+        with database.get_connection() as conn:
+            for i, out in enumerate(outcomes):
+                conn.execute(
+                    "UPDATE model_log SET home_win = ? WHERE home_team = ?",
+                    (int(out), f"T{i}"),
+                )
+
+        state = calibration.update_blend_weight()
+        assert state is not None
+        assert state["weight"] <= 0.5
+        # Never goes below the hard floor
+        assert state["weight"] >= calibration.BLEND_WEIGHT_MIN

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -6,12 +6,14 @@ from evaluate import (
     calculate_edge,
     size_bet,
     blend_with_market,
+    compute_confidence,
     filter_positive_ev,
     filter_totals_ev,
     total_over_probability,
     format_picks,
     format_stats,
 )
+from config import TOTALS_MAX_DISAGREEMENT
 
 
 # ---------------------------------------------------------------------------
@@ -286,6 +288,46 @@ class TestFilterTotalsEV:
 
     def test_empty_input(self):
         assert filter_positive_ev([]) == []
+
+
+# ---------------------------------------------------------------------------
+# compute_confidence
+# ---------------------------------------------------------------------------
+
+class TestComputeConfidence:
+    """Stars are scaled to the ACHIEVABLE edge band: with blend weight w and
+    disagreement cap c, no pick can exceed an edge of (1-w)*c. At the default
+    w=0.5 the moneyline band is [0.05, 0.075] and the totals band [0.05, 0.15].
+    """
+
+    def test_threshold_edge_is_one_star(self):
+        assert compute_confidence(0.05, 0.05) == 1
+
+    def test_max_achievable_edge_is_five_stars(self):
+        assert compute_confidence(0.075, 0.10) == 5
+
+    def test_all_tiers_reachable(self):
+        edges = (0.051, 0.056, 0.062, 0.068, 0.074)
+        stars = [compute_confidence(e, 0.05) for e in edges]
+        assert stars == [1, 2, 3, 4, 5]
+
+    def test_monotonic_in_edge(self):
+        stars = [compute_confidence(e, 0.05) for e in (0.05, 0.06, 0.07, 0.075)]
+        assert stars == sorted(stars)
+
+    def test_totals_band_uses_wider_cap(self):
+        # Same edge maps to fewer stars on totals because the band is wider.
+        ml = compute_confidence(0.074, 0.05)
+        ou = compute_confidence(0.074, 0.05,
+                                max_disagreement=TOTALS_MAX_DISAGREEMENT, weight=0.5)
+        assert ml == 5
+        assert ou < ml
+        assert compute_confidence(0.149, 0.2,
+                                  max_disagreement=TOTALS_MAX_DISAGREEMENT, weight=0.5) == 5
+
+    def test_never_below_one_or_above_five(self):
+        assert compute_confidence(0.0, 0.0) == 1
+        assert compute_confidence(0.5, 1.0) == 5
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -1,0 +1,44 @@
+"""Tests for score.py — analytical run estimates."""
+
+import pytest
+
+from score import predict_game_scores, _BASE_RUNS
+
+
+def _features(park=1.0, **overrides):
+    base = {
+        "home_p_xFIP_season": 4.50, "away_p_xFIP_season": 4.50,
+        "home_hit_ops": 0.720, "away_hit_ops": 0.720,
+        "park_factor": park,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestPredictGameScores:
+    def test_league_average_matchup(self):
+        scores = predict_game_scores(_features())
+        # Both sides near base runs; home gets the small home-field bump
+        assert scores["predicted_away_score"] == pytest.approx(_BASE_RUNS, abs=0.01)
+        assert scores["predicted_home_score"] > scores["predicted_away_score"]
+        assert scores["predicted_total"] == pytest.approx(
+            scores["predicted_home_score"] + scores["predicted_away_score"], abs=0.02)
+
+    def test_park_factor_boosts_both_teams(self):
+        # Both teams hit in the same stadium — a hitter's park must raise
+        # BOTH run estimates, not just the home team's.
+        neutral = predict_game_scores(_features(park=1.0))
+        coors = predict_game_scores(_features(park=1.22))
+        assert coors["predicted_home_score"] > neutral["predicted_home_score"]
+        assert coors["predicted_away_score"] > neutral["predicted_away_score"]
+        assert coors["predicted_away_score"] == pytest.approx(
+            neutral["predicted_away_score"] * 1.22, abs=0.05)
+
+    def test_better_opposing_pitcher_lowers_runs(self):
+        vs_ace = predict_game_scores(_features(away_p_xFIP_season=2.80))
+        vs_avg = predict_game_scores(_features(away_p_xFIP_season=4.50))
+        assert vs_ace["predicted_home_score"] < vs_avg["predicted_home_score"]
+
+    def test_missing_features_fall_back_to_league_average(self):
+        scores = predict_game_scores({})
+        assert scores["predicted_total"] > 0


### PR DESCRIPTION
## Summary

Full review of the model + pick logic, a new self-improving ML feedback loop, and dashboard UX upgrades.

### Logic review findings (fixed here)

| Issue | Fix |
|---|---|
| `score.py` applied the park factor only to the **home** offense, but both teams hit in the same stadium. Totals picks were biased in extreme parks (e.g. away offense at Coors underestimated by 22%). | Park factor now applies to both teams' run estimates. |
| Confidence stars were unreachable: with a 0.5 blend weight and the 0.15 disagreement cap, no moneyline pick can exceed a 7.5% edge, so the old "5★ at 10% edge" tiers pinned everything at 2–3 stars. | Stars now split the **achievable** band `[EV_THRESHOLD, (1−w)·cap]` into five equal tiers, and adapt to the active blend weight and market type (moneyline vs totals). |
| `size_bet` docstring claimed "no artificial floor" while the code floors at `MIN_BET_UNITS`. | Docstring corrected. |

The core EV pipeline (de-vig → disagreement cap → market blend → half-Kelly with cap) is sound and unchanged.

### Self-improving ML loop (`calibration.py`)

The graded track record (319 bets, 44.8% win rate, Brier 0.2514) shows pick probabilities are still overconfident even after blending — the blend weight is the single most consequential free parameter, and it can now be **learned from the model's own results**:

1. Every prediction day, the raw model prob + de-vigged market prob is logged for **every game with odds** (full slate → no adverse-selection bias) into a new `model_log` table.
2. Grading attaches actual outcomes.
3. After each grading run, a grid search finds the blend weight minimizing log loss on all graded games and persists it to `models/blend_state.json` (committed by the daily-grade workflow).
4. Picks use the learned weight once ≥150 graded games exist, hard-clamped to [0.30, 0.95]. Totals keep the static weight, since the learned weight is specific to the moneyline classifier.

Picks also now store their pre-blend `raw_model_prob` for auditability. The weekly full retrain on fresh season data continues unchanged — this adds a second, faster feedback loop on top of it.

### Dashboard UX

- **Market filter** (Moneyline / Totals / All) — totals picks were previously invisible in history, stats, and the P&L chart.
- **Last 30d** time range alongside YTD / All-Time.
- Pick cards show the **pitching matchup** and **raw → blended** model probability.
- Self-tuning status banner (driven by a new `model` section in `stats.json`) so visitors can see the calibration state.
- Explanatory tooltips on history-table headers (Odds, Units, Model%, Edge, Conf).

### Tests

`177 passed` — new suites for calibration (storage, grading, weight learning on synthetic data where the optimum is known) and the score model; confidence-tier tests; `conftest.py` pins the blend weight to the default so pick-filter tests stay deterministic regardless of any committed blend state.

https://claude.ai/code/session_018dTk64XtoLwJTbVXwqvyXp

---
_Generated by [Claude Code](https://claude.ai/code/session_018dTk64XtoLwJTbVXwqvyXp)_