### PR TITLE
Fix picks not posting: spread crons earlier and chain predict off Daily Grade

### DIFF
--- a/.github/workflows/daily-predict.yml
+++ b/.github/workflows/daily-predict.yml
@@ -3,15 +3,25 @@ name: Daily Predictions
 on:
   schedule:
     # Target: post by 11:00 AM ET. (MLB season is entirely EDT, so 11:00 ET =
-    # 15:00 UTC.) GitHub `schedule` crons are best-effort — at busy times
-    # (especially the top/half of the hour) they are delayed by hours or DROPPED
-    # entirely with no run created, which is how a day's predictions silently
-    # fail to post. We therefore fire several times around the target at
-    # off-peak, non-round minutes. The run is idempotent (see PREDICT_STATUS_FILE
-    # in main.py), so once one attempt posts the later ones cheaply no-op.
-    - cron: '4 15 * * *'    # ~11:04 ET — primary (the 11am target)
-    - cron: '34 15 * * *'   # ~11:34 ET — backup if primary was dropped
+    # 15:00 UTC.) GitHub `schedule` crons are best-effort — and in this repo the
+    # observed delay is 2-3 HOURS, with every cron of the day shifted late
+    # together (2026-06-09: the 15:04 cron fired at 17:27) or dropped outright
+    # (2026-06-10: none of the three crons ever created a run). Clustering
+    # backups around the target time therefore doesn't help. Instead, attempts
+    # are spread from early morning onward so that even a 3-hour delay still
+    # lands before the 11 ET target. The run is idempotent (see
+    # PREDICT_STATUS_FILE in main.py) and gated cheaply below, so once one
+    # attempt posts, later attempts no-op in seconds.
+    - cron: '3 12 * * *'    # ~8:03 ET nominal — lands near 11 ET under typical delay
+    - cron: '33 13 * * *'   # ~9:33 ET nominal
+    - cron: '4 15 * * *'    # ~11:04 ET — the on-time target
     - cron: '19 16 * * *'   # ~12:19 ET — last-chance before most first pitches
+  # Daily Grade's cron has fired every morning even on days the predict crons
+  # were dropped, so chain off its completion as an additional trigger.
+  # workflow_run events fire promptly (they are not subject to cron delays).
+  workflow_run:
+    workflows: ["Daily Grade"]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -24,12 +34,31 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # With several redundant triggers a day, most runs arrive after picks have
+      # already posted. Bail out before the expensive Python/pip setup so the
+      # redundancy stays cheap. main.py has the same guard, so this is purely an
+      # optimization — removing it changes nothing but run time.
+      - name: Check whether today's picks already posted
+        id: gate
+        run: |
+          TODAY=$(date -u +%Y-%m-%d)
+          MARKER=$(python3 -c "import json;print(json.load(open('docs/data/predict_status.json')).get('date',''))" 2>/dev/null || echo "")
+          if [ "$MARKER" = "$TODAY" ]; then
+            echo "Predictions already posted for $TODAY — nothing to do."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No predictions yet for $TODAY (marker='$MARKER') — running pipeline."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/setup-python@v5
+        if: steps.gate.outputs.skip == 'false'
         with:
           python-version: '3.12'
           cache: 'pip'
 
       - name: Restore feature cache
+        if: steps.gate.outputs.skip == 'false'
         uses: actions/cache@v4
         with:
           path: models/cache
@@ -38,8 +67,10 @@ jobs:
             feature-cache-
 
       - run: pip install -r requirements.txt
+        if: steps.gate.outputs.skip == 'false'
 
       - name: Retrain if models are missing or feature schema changed
+        if: steps.gate.outputs.skip == 'false'
         run: |
           python -c "
           import json, hashlib, sys
@@ -59,6 +90,7 @@ jobs:
           " || python main.py --retrain
 
       - name: Commit retrained models if schema changed
+        if: steps.gate.outputs.skip == 'false'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -66,6 +98,7 @@ jobs:
           git diff --cached --quiet || git commit -m "chore: retrain models (schema change) $(date -u +%Y-%m-%d)"
 
       - name: Run today's predictions
+        if: steps.gate.outputs.skip == 'false'
         env:
           ODDS_API_KEY: ${{ secrets.ODDS_API_KEY }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
@@ -76,6 +109,7 @@ jobs:
         run: python main.py --run-now
 
       - name: Commit updated database and dashboard data
+        if: steps.gate.outputs.skip == 'false'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/predict-watchdog.yml
+++ b/.github/workflows/predict-watchdog.yml
@@ -2,16 +2,21 @@ name: Predictions Watchdog
 
 # Safety net for the Daily Predictions workflow. GitHub `schedule` crons are
 # best-effort and can be delayed for hours or dropped entirely, so even the
-# three redundant predict triggers could in theory all miss. This watchdog runs
-# once, after the last predict attempt, checks whether today's picks actually
-# posted (via docs/data/predict_status.json), and if not it runs the pipeline
-# itself and reports the outcome to Discord. It needs no PAT or external
-# service: it self-heals in-process rather than trying to re-dispatch a
-# workflow (which the built-in GITHUB_TOKEN is not permitted to do).
+# redundant predict triggers can all miss (this happened on 2026-06-10). This
+# watchdog runs after the last predict attempt, checks whether today's picks
+# actually posted (via docs/data/predict_status.json), and if not it runs the
+# pipeline itself and reports the outcome to Discord. It needs no PAT or
+# external service: it self-heals in-process rather than trying to re-dispatch
+# a workflow (which the built-in GITHUB_TOKEN is not permitted to do).
 
 on:
   schedule:
+    # Multiple crons because the watchdog itself is subject to the same 2-3h
+    # scheduler delays/drops it guards against. When healthy, each extra run
+    # is just a checkout + marker check (a few seconds).
     - cron: '11 17 * * *'   # ~13:11 ET — after the 12:19 ET last-chance predict run
+    - cron: '47 18 * * *'   # ~14:47 ET — backup sweep
+    - cron: '29 20 * * *'   # ~16:29 ET — final sweep before evening games
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Problem

No picks posted to the site today (2026-06-10). The pipeline itself is healthy — the trigger never fired:

- All three Daily Predictions crons (15:04 / 15:34 / 16:19 UTC) were **dropped by GitHub's scheduler** — zero runs created as of 17:00 UTC.
- This is systemic: GitHub is delaying this repo's crons by **2–3 hours, with every cron of the day shifted late together**. On 2026-06-09 the 15:04 cron fired at 17:27, 15:34 at 17:33, 16:19 at 18:24 — picks posted at 1:27pm ET, after first pitch. Daily Grade (cron 12:00 UTC) ran at 14:53 today, ~3h late.
- The June 8 fix (redundant crons clustered around 11am ET + single-cron watchdog at 17:11 UTC) doesn't survive this failure mode: the backups shift late together with the primary, and the watchdog suffers the same delay, rescuing around 4pm ET at best.

## Fix

**daily-predict.yml**
- Spread crons from early morning (8:03 / 9:33 ET nominal) through the existing 11:04 / 12:19 ET slots, so even a 3-hour delay lands near the 11am ET target. The run is already idempotent, so the first attempt to fire wins and the rest no-op.
- Add a `workflow_run` trigger on **Daily Grade** completion. `workflow_run` events fire promptly (not subject to cron delays), and grade's cron has fired every morning even on days the predict crons were dropped — today it would have posted picks at ~10:55am ET.
- Add a cheap gate right after checkout that skips Python/pip setup when today's picks already posted, so the extra redundancy costs seconds per no-op run instead of minutes.

**predict-watchdog.yml**
- Three crons (13:11 / 14:47 / 16:29 ET) instead of one, so the safety net isn't taken out by the same scheduler delays it guards against.

## Today's picks

These workflow changes only take effect once merged to `master` (scheduled and `workflow_run` triggers read the default branch). Today's run was recovered separately via `workflow_dispatch`.

https://claude.ai/code/session_01DA2t2w2fqi9w3ZP7FTmTdX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DA2t2w2fqi9w3ZP7FTmTdX)_