### PR TITLE
Bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/daily-grade.yml
+++ b/.github/workflows/daily-grade.yml
@@ -12,9 +12,9 @@ jobs:
   grade:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'pip'

--- a/.github/workflows/daily-predict.yml
+++ b/.github/workflows/daily-predict.yml
@@ -32,7 +32,7 @@ jobs:
   predict:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # With several redundant triggers a day, most runs arrive after picks have
       # already posted. Bail out before the expensive Python/pip setup so the
@@ -51,7 +51,7 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         if: steps.gate.outputs.skip == 'false'
         with:
           python-version: '3.12'
@@ -59,7 +59,7 @@ jobs:
 
       - name: Restore feature cache
         if: steps.gate.outputs.skip == 'false'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: models/cache
           key: feature-cache-${{ hashFiles('features.py') }}

--- a/.github/workflows/predict-watchdog.yml
+++ b/.github/workflows/predict-watchdog.yml
@@ -26,7 +26,7 @@ jobs:
   watchdog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check whether predictions already posted today
         id: check
@@ -41,7 +41,7 @@ jobs:
             echo "posted=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         if: steps.check.outputs.posted == 'false'
         with:
           python-version: '3.12'
@@ -49,7 +49,7 @@ jobs:
 
       - name: Restore feature cache
         if: steps.check.outputs.posted == 'false'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: models/cache
           key: feature-cache-${{ hashFiles('features.py') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,9 +13,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'pip'

--- a/.github/workflows/weekly-retrain.yml
+++ b/.github/workflows/weekly-retrain.yml
@@ -12,15 +12,15 @@ jobs:
   retrain:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'pip'
 
       - name: Restore feature cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: models/cache
           key: feature-cache-${{ hashFiles('features.py') }}


### PR DESCRIPTION
Workflow runs are warning that Node 20 actions are deprecated — GitHub forces Node 24 on **June 16th, 2026** and removes Node 20 from runners on September 16th, 2026.

This bumps every workflow to the Node 24 release of the same action:

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | v5 |
| `actions/setup-python` | v5 | v6 |
| `actions/cache` | v4 | v5 |

Touches `daily-predict`, `daily-grade`, `predict-watchdog`, `weekly-retrain`, and `tests`. No behavior changes — checkout v5, setup-python v6, and cache v5 are the runtime bumps of the versions already in use (checkout v6 was skipped deliberately since it changes credential persistence, which the daily workflows rely on for `git push`).

https://claude.ai/code/session_01DA2t2w2fqi9w3ZP7FTmTdX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DA2t2w2fqi9w3ZP7FTmTdX)_