### PR TITLE
Include Over/Under picks in the record and stats from June 1st

### DIFF
--- a/config.py
+++ b/config.py
@@ -51,6 +51,10 @@ MAX_BET_UNITS = 3.0   # Cap: never risk more than this per pick
 # betting window while still rejecting wild (>~2.5 run) model-vs-line gaps.
 TOTALS_SIGMA = 3.0
 TOTALS_MAX_DISAGREEMENT = 0.30
+# Totals picks count toward the official record/ROI from this date onward.
+# Earlier O/U picks (May 2026) came from the pre-fix score/confidence logic
+# and stay visible in the raw history but are excluded from the score.
+TOTALS_TRACKED_SINCE = "2026-06-01"
 
 # --- Market blending & adverse-selection guards ---
 # The raw model is miscalibrated/under-dispersed and systematically overrates the

--- a/database.py
+++ b/database.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 import pandas as pd
 
-from config import DB_PATH, SUPABASE_URL, SUPABASE_SERVICE_KEY
+from config import DB_PATH, SUPABASE_URL, SUPABASE_SERVICE_KEY, TOTALS_TRACKED_SINCE
 
 logger = logging.getLogger(__name__)
 
@@ -296,15 +296,21 @@ def get_pending_dates() -> list[str]:
     return [r["date"] for r in rows]
 
 
+# The official record: every moneyline pick, plus totals (Over/Under) picks
+# from TOTALS_TRACKED_SINCE onward (earlier totals were experimental).
+_RECORD_FILTER = ("(bet_type = 'moneyline' OR bet_type IS NULL "
+                  "OR (bet_type = 'totals' AND date >= ?))")
+
+
 def get_roi_stats(since: Optional[str] = None) -> dict:
-    """Calculate ROI statistics.
+    """Calculate ROI statistics across moneyline and tracked totals picks.
 
     Returns dict with: total_bets, wins, losses, pending, total_units_wagered,
     total_profit, roi_pct, brier_score, win_rate.
     """
     with get_connection() as conn:
-        where = "WHERE status != 'Pending' AND (bet_type = 'moneyline' OR bet_type IS NULL)"
-        params = []
+        where = f"WHERE status != 'Pending' AND {_RECORD_FILTER}"
+        params = [TOTALS_TRACKED_SINCE]
         if since:
             where += " AND date >= ?"
             params.append(since)
@@ -316,8 +322,9 @@ def get_roi_stats(since: Optional[str] = None) -> dict:
 
     if not rows:
         with get_connection() as conn:
-            pending_sql = "SELECT COUNT(*) as cnt FROM predictions WHERE status = 'Pending' AND (bet_type = 'moneyline' OR bet_type IS NULL)"
-            pending_params = []
+            pending_sql = (f"SELECT COUNT(*) as cnt FROM predictions "
+                           f"WHERE status = 'Pending' AND {_RECORD_FILTER}")
+            pending_params = [TOTALS_TRACKED_SINCE]
             if since:
                 pending_sql += " AND date >= ?"
                 pending_params.append(since)
@@ -341,8 +348,9 @@ def get_roi_stats(since: Optional[str] = None) -> dict:
     brier_score = brier_sum / len(rows)
 
     with get_connection() as conn:
-        pending_sql = "SELECT COUNT(*) as cnt FROM predictions WHERE status = 'Pending'"
-        pending_params = []
+        pending_sql = (f"SELECT COUNT(*) as cnt FROM predictions "
+                       f"WHERE status = 'Pending' AND {_RECORD_FILTER}")
+        pending_params = [TOTALS_TRACKED_SINCE]
         if since:
             pending_sql += " AND date >= ?"
             pending_params.append(since)

--- a/docs/data/stats.json
+++ b/docs/data/stats.json
@@ -1,26 +1,26 @@
 {
   "ytd": {
-    "total_bets": 325,
-    "wins": 148,
-    "losses": 177,
+    "total_bets": 338,
+    "wins": 159,
+    "losses": 179,
     "pending": 8,
-    "total_units_wagered": 458.16,
-    "total_profit": 18.34,
-    "roi_pct": 4.0,
-    "brier_score": 0.2506,
-    "win_rate": 45.54,
+    "total_units_wagered": 471.63000000000005,
+    "total_profit": 27.89,
+    "roi_pct": 5.91,
+    "brier_score": 0.2481,
+    "win_rate": 47.04,
     "since": "2026-01-01"
   },
   "all_time": {
-    "total_bets": 325,
-    "wins": 148,
-    "losses": 177,
+    "total_bets": 338,
+    "wins": 159,
+    "losses": 179,
     "pending": 8,
-    "total_units_wagered": 458.16,
-    "total_profit": 18.34,
-    "roi_pct": 4.0,
-    "brier_score": 0.2506,
-    "win_rate": 45.54
+    "total_units_wagered": 471.63000000000005,
+    "total_profit": 27.89,
+    "roi_pct": 5.91,
+    "brier_score": 0.2481,
+    "win_rate": 47.04
   },
   "model": {
     "blend_weight": 0.5,
@@ -28,5 +28,5 @@
     "calibration_games": 0,
     "calibration_updated": null
   },
-  "last_updated": "2026-06-11T15:36:46.729881Z"
+  "last_updated": "2026-06-11T15:48:57.708611Z"
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -54,9 +54,9 @@
           <button class="toggle-btn"        data-mode="all_time">All-Time</button>
         </div>
         <div class="toggle-group" role="group" aria-label="Market">
-          <button class="toggle-btn active" data-market="moneyline">Moneyline</button>
+          <button class="toggle-btn"        data-market="moneyline">Moneyline</button>
           <button class="toggle-btn"        data-market="totals">Totals</button>
-          <button class="toggle-btn"        data-market="all">All</button>
+          <button class="toggle-btn active" data-market="all">All</button>
         </div>
       </div>
 

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -6,8 +6,12 @@ let allHistory  = [];
 let statsData   = {};
 let chart       = null;
 let mode        = 'ytd';        // 'ytd' | 'last30' | 'all_time'
-let market      = 'moneyline';  // 'moneyline' | 'totals' | 'all'
+let market      = 'all';        // 'moneyline' | 'totals' | 'all'
 let filterText  = '';
+
+// Totals (O/U) picks count toward the record from this date onward; earlier
+// totals picks were experimental (pre-fix score model) and are excluded.
+const TOTALS_TRACKED_SINCE = '2026-06-01';
 
 // ── Fetch ──────────────────────────────────────────────────────────────────
 async function loadData() {
@@ -65,10 +69,17 @@ function easternDateStr() {
   return new Date().toLocaleDateString('en-CA', { timeZone: 'America/New_York' });
 }
 
+// True when a totals row falls inside the tracked O/U window.
+function totalsTracked(p) {
+  return p.bet_type === 'totals' && p.date && p.date >= TOTALS_TRACKED_SINCE;
+}
+
 // Apply the active market filter (moneyline / totals / all) to history rows.
 function marketFiltered(history) {
-  if (market === 'all') return history;
-  if (market === 'totals') return history.filter(p => p.bet_type === 'totals');
+  if (market === 'all') {
+    return history.filter(p => p.bet_type !== 'totals' || totalsTracked(p));
+  }
+  if (market === 'totals') return history.filter(totalsTracked);
   return history.filter(p => !p.bet_type || p.bet_type === 'moneyline');
 }
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -265,6 +265,62 @@ class TestGetROIStats:
         assert stats["total_bets"] == 0  # pending not counted in totals
 
 
+def _make_totals_pick(**overrides):
+    base = _make_pick(
+        pick="Over", pick_side="Over", bet_type="totals",
+        listed_total=8.5, date="2026-06-09",
+    )
+    base.update(overrides)
+    return base
+
+
+class TestROIStatsIncludeTotals:
+    """Totals (O/U) picks count toward the record from TOTALS_TRACKED_SINCE."""
+
+    def test_tracked_totals_counted(self, tmp_db):
+        with patch("database.DB_PATH", tmp_db):
+            database.save_predictions([_make_totals_pick(units=1, odds=100)],
+                                      bet_type="totals")
+            results = {"BOS @ NYY": {"home_score": 6, "away_score": 4, "winner": "NYY"}}
+            database.grade_predictions(results)  # total 10 > 8.5 → Over wins
+            stats = database.get_roi_stats()
+        assert stats["total_bets"] == 1
+        assert stats["wins"] == 1
+        assert stats["total_profit"] == pytest.approx(1.0, abs=1e-4)
+
+    def test_pre_cutoff_totals_excluded(self, tmp_db):
+        with patch("database.DB_PATH", tmp_db):
+            database.save_predictions([_make_totals_pick(date="2026-05-02")],
+                                      bet_type="totals")
+            results = {"BOS @ NYY": {"home_score": 6, "away_score": 4, "winner": "NYY"}}
+            database.grade_predictions(results)
+            stats = database.get_roi_stats()
+        assert stats["total_bets"] == 0
+
+    def test_pending_totals_counted_after_cutoff_only(self, tmp_db):
+        with patch("database.DB_PATH", tmp_db):
+            database.save_predictions(
+                [_make_totals_pick(date="2026-05-02"),
+                 _make_totals_pick(date="2026-06-09")],
+                bet_type="totals",
+            )  # both left Pending
+            stats = database.get_roi_stats()
+        assert stats["pending"] == 1
+
+    def test_moneyline_and_totals_combined(self, tmp_db):
+        with patch("database.DB_PATH", tmp_db):
+            database.save_predictions([_make_pick(date="2026-06-09", pick="NYY",
+                                                  units=1, odds=100)])
+            database.save_predictions([_make_totals_pick(pick="Under", pick_side="Under",
+                                                         units=1, odds=100)],
+                                      bet_type="totals")
+            results = {"BOS @ NYY": {"home_score": 5, "away_score": 3, "winner": "NYY"}}
+            database.grade_predictions(results)  # ML wins; total 8 < 8.5 → Under wins
+            stats = database.get_roi_stats()
+        assert stats["total_bets"] == 2
+        assert stats["wins"] == 2
+
+
 class TestGradeBackfillByDate:
     """Date-scoped grading: a result must only grade picks on the matching date."""
 


### PR DESCRIPTION
## Summary
The score/record only counted moneyline bets — `get_roi_stats` (which feeds `stats.json` and the console lifetime stats) excluded totals entirely, and the dashboard defaulted to the moneyline-only view. Graded Over/Under picks never showed up in the headline record.

This makes the record and results log reflect O/U picks **as of June 1st**:

- Added `TOTALS_TRACKED_SINCE = "2026-06-01"` to `config.py`. The May 2–3 totals batch (made under the old, since-fixed score/confidence logic) stays visible in raw history but is excluded from the official record.
- `get_roi_stats` now counts totals picks dated on/after the cutoff alongside all moneyline picks (graded and pending). Also fixed an inconsistency where one pending-count path counted all pending rows regardless of bet type.
- Dashboard now defaults to the combined **All** market view, and applies the same June 1 cutoff to the stats cards, cumulative P&L chart, and pick-history table. The Moneyline/Totals toggles still work for per-market views.
- Re-exported `docs/data/stats.json`: the record goes from 325 bets (148W–177L, +18.34u, 4.0% ROI) to **338 bets (159W–179L, +27.89u, 5.91% ROI)** with the June 9–10 totals picks now counted.

## Testing
- Added 4 tests covering totals inclusion, the pre-cutoff exclusion, pending counts, and the combined moneyline+totals record.
- Full suite: **181 passed**.

https://claude.ai/code/session_01SHifbSsP3xetfWAyKpahYs

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHifbSsP3xetfWAyKpahYs)_