### PR TITLE
Show over/unders in Pick History by default

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -54,9 +54,9 @@
           <button class="toggle-btn"        data-mode="all_time">All-Time</button>
         </div>
         <div class="toggle-group" role="group" aria-label="Market">
-          <button class="toggle-btn active" data-market="moneyline">Moneyline</button>
+          <button class="toggle-btn"        data-market="moneyline">Moneyline</button>
           <button class="toggle-btn"        data-market="totals">Totals</button>
-          <button class="toggle-btn"        data-market="all">All</button>
+          <button class="toggle-btn active" data-market="all">All</button>
         </div>
       </div>
 

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -6,7 +6,7 @@ let allHistory  = [];
 let statsData   = {};
 let chart       = null;
 let mode        = 'ytd';        // 'ytd' | 'last30' | 'all_time'
-let market      = 'moneyline';  // 'moneyline' | 'totals' | 'all'
+let market      = 'all';        // 'moneyline' | 'totals' | 'all'
 let filterText  = '';
 
 // ── Fetch ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What & why

The Pick History table was defaulting to the **Moneyline** market filter, so over/under (totals) picks were hidden until you manually clicked the `Totals` or `All` toggle. That also made days that had **only** totals picks look like they were skipped.

This changes the default market filter to **All**, so Pick History now includes over/unders alongside moneyline out of the box.

## Effect on the dates in question (June 2026)

- **Over/unders now visible** — 41 totals rows across June now appear in the default Pick History view.
- **Previously "skipped" days restored** — `2026-06-11` and `2026-06-12` had *only* totals picks, so they vanished in the moneyline-only default. They now show up.
- **Genuinely empty days** — `2026-06-03`, `2026-06-06`, and `2026-06-07` produced **zero +EV picks** when the pipeline ran (verified in git history and the database). There's nothing to display for those, so they remain absent.
- **6/1–6/8 totals** — the totals feature wasn't generating picks consistently until ~6/9, so those days have moneyline picks only. No stored odds/score data exists to backfill real O/U picks for them.

## Changes

- `docs/js/dashboard.js` — default `market` state `'moneyline'` → `'all'`.
- `docs/index.html` — move the `active` class from the Moneyline toggle to the All toggle.

Users can still narrow to Moneyline or Totals with the existing toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WY5ddfy8nCQS5ngeaDUkcb)_