### PR TITLE
chore: update dashboard stats JSON from daily pipeline run (2026-06-20)

### DIFF
--- a/docs/data/stats.json
+++ b/docs/data/stats.json
@@ -4,7 +4,7 @@
     "wins": 160,
     "losses": 186,
     "pending": 12,
-    "total_units_wagered": 470.2,
+    "total_units_wagered": 470.19999999999993,
     "total_profit": 19.69,
     "roi_pct": 4.19,
     "brier_score": 0.2497,
@@ -16,7 +16,7 @@
     "wins": 160,
     "losses": 186,
     "pending": 12,
-    "total_units_wagered": 470.2,
+    "total_units_wagered": 470.19999999999993,
     "total_profit": 19.69,
     "roi_pct": 4.19,
     "brier_score": 0.2497,
@@ -28,5 +28,5 @@
     "calibration_games": 0,
     "calibration_updated": null
   },
-  "last_updated": "2026-06-20T13:28:49.327179Z"
+  "last_updated": "2026-06-20T15:37:58.612376Z"
 }


### PR DESCRIPTION
## Summary

- Updates `docs/data/stats.json` with refreshed `last_updated` timestamp from today's pipeline run (2026-06-20T15:36:26Z)
- Minor float precision change: `470.2` → `470.19999999999993` (no functional difference)

## Pipeline run notes

**Today's picks (7 bets posted):**
- LAA @ ATH — Under -106 (+8.6% edge) ⭐ Pick of the Day
- MIL @ ATL — Under -104 (+8.4% edge)
- NYM @ PHI — Under -114 (+8.4% edge)
- SF @ MIA — MIA -138 (+7.4% edge)
- SF @ MIA — Under -110 (+5.6% edge)
- TOR @ CHC — CHC -130 (+5.6% edge)
- NYM @ PHI — PHI -187 (+5.1% edge)

**Lifetime stats:** 346 bets, 160W–186L (46.2%), +19.69u, +4.19% ROI

**⚠️ Issue:** `statsapi.mlb.com` returning 403 Forbidden from this environment — grading of 12 pending bets is blocked. May need IP change or alternative data source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMT1BeVfuQZfBbraCXEc6Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMT1BeVfuQZfBbraCXEc6Z)_