### PR TITLE
Fix model defects causing zero out-of-sample skill

### DIFF
--- a/calibration.py
+++ b/calibration.py
@@ -173,14 +173,40 @@ def update_blend_weight() -> Optional[dict]:
     market_loss = round(_blend_log_loss(1.0, model, market, y), 5)
     default_loss = round(_blend_log_loss(MARKET_BLEND_WEIGHT, model, market, y), 5)
 
+    # Health checks. The grid is clamped to BLEND_WEIGHT_MAX, so a weight that
+    # lands exactly on the ceiling means the unconstrained optimum is "ignore
+    # the model entirely" — the search was cut off, not satisfied. And if the
+    # best blend cannot beat pure market, the model is contributing negative
+    # information and no amount of blending will make it +EV. Both conditions
+    # were previously invisible: the state file just showed a plausible-looking
+    # weight and the pipeline carried on emitting (or silently not emitting) picks.
+    at_ceiling = best_weight >= BLEND_WEIGHT_MAX - 1e-9
+    adds_value = best_loss < market_loss
+
     state = {
         "weight": best_weight,
         "n_games": n,
         "log_loss": best_loss,
         "default_weight_log_loss": default_loss,
         "pure_market_log_loss": market_loss,
+        "weight_at_ceiling": at_ceiling,
+        "model_adds_value": adds_value,
         "updated_at": datetime.utcnow().isoformat() + "Z",
     }
+
+    if not adds_value:
+        logger.error(
+            "MODEL HEALTH: blending cannot beat the market (best log loss %.5f "
+            "vs %.5f pure market on %d games). The model is adding no "
+            "information — retrain before betting it.",
+            best_loss, market_loss, n,
+        )
+    elif at_ceiling:
+        logger.warning(
+            "MODEL HEALTH: learned blend weight is pinned at the %.2f ceiling; "
+            "the unconstrained optimum is to trust the market even more.",
+            BLEND_WEIGHT_MAX,
+        )
     BLEND_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
     BLEND_STATE_PATH.write_text(json.dumps(state, indent=2))
     _invalidate_cache()

--- a/database.py
+++ b/database.py
@@ -80,6 +80,13 @@ def _migrate_db(conn: sqlite3.Connection):
         ("confidence", "INTEGER"),
         # Pre-blend model probability, kept for calibration audits
         ("raw_model_prob", "REAL"),
+        # Final score, captured at grading time. Without these the totals model
+        # can never be calibrated: TOTALS_SIGMA and the run-scale constants in
+        # score.py have to be fit against real residuals, and the residuals
+        # were being thrown away.
+        ("actual_home_score", "INTEGER"),
+        ("actual_away_score", "INTEGER"),
+        ("actual_total", "REAL"),
     ]
     for col, col_type in new_columns:
         if col not in existing:
@@ -173,23 +180,33 @@ def grade_predictions(results: dict[str, dict], for_date: Optional[str] = None):
             pick  = row["pick"]
             units = row["units"]
             odds  = row["odds"]
+            home_score = result.get("home_score", 0)
+            away_score = result.get("away_score", 0)
+            actual_total = home_score + away_score
 
             # Determine winner depending on bet type
             bet_type = row["bet_type"] if "bet_type" in row.keys() else "moneyline"
             if bet_type == "totals":
-                actual_total = result.get("home_score", 0) + result.get("away_score", 0)
                 listed = row["listed_total"] if "listed_total" in row.keys() else None
-                if listed is not None:
-                    actual_winner = "Over" if actual_total > listed else "Under"
-                else:
+                if listed is None:
                     actual_winner = None
+                elif actual_total == listed:
+                    # Whole-number line landing exactly on the total is a PUSH:
+                    # the stake is returned. Grading it as "Under" (the old
+                    # behaviour) booked a full-unit loss on every push and
+                    # understated the totals record.
+                    actual_winner = "Push"
+                else:
+                    actual_winner = "Over" if actual_total > listed else "Under"
             else:
                 actual_winner = result["winner"]
 
             if actual_winner is None:
                 continue
 
-            if actual_winner == pick:
+            if actual_winner == "Push":
+                status, profit = "Push", 0.0
+            elif actual_winner == pick:
                 status = "Win"
                 if odds > 0:
                     profit = units * (odds / 100)
@@ -200,8 +217,11 @@ def grade_predictions(results: dict[str, dict], for_date: Optional[str] = None):
                 profit = -units
 
             conn.execute(
-                "UPDATE predictions SET status = ?, result = ?, profit = ? WHERE id = ?",
-                (status, actual_winner, profit, row["id"]),
+                "UPDATE predictions SET status = ?, result = ?, profit = ?, "
+                "actual_home_score = ?, actual_away_score = ?, actual_total = ? "
+                "WHERE id = ?",
+                (status, actual_winner, profit, home_score, away_score,
+                 actual_total, row["id"]),
             )
             graded += 1
 
@@ -296,15 +316,35 @@ def get_pending_dates() -> list[str]:
     return [r["date"] for r in rows]
 
 
-def get_roi_stats(since: Optional[str] = None) -> dict:
+def get_roi_stats(since: Optional[str] = None,
+                  bet_type: Optional[str] = None) -> dict:
     """Calculate ROI statistics.
 
-    Returns dict with: total_bets, wins, losses, pending, total_units_wagered,
-    total_profit, roi_pct, brier_score, win_rate.
+    Args:
+        since: Only count picks on or after this ISO date.
+        bet_type: Restrict to one market ("moneyline" or "totals"). None (the
+            default) covers every market.
+
+    Pushes are excluded from the win/loss record and from the ROI denominator
+    (the stake is returned), but are reported in their own ``pushes`` count.
+
+    Returns dict with: total_bets, wins, losses, pushes, pending,
+    total_units_wagered, total_profit, roi_pct, brier_score, win_rate.
     """
+    # A NULL bet_type predates the totals migration and means moneyline.
+    if bet_type == "moneyline":
+        type_clause = " AND (bet_type = 'moneyline' OR bet_type IS NULL)"
+        type_params: list = []
+    elif bet_type:
+        type_clause = " AND bet_type = ?"
+        type_params = [bet_type]
+    else:
+        type_clause = ""
+        type_params = []
+
     with get_connection() as conn:
-        where = "WHERE status != 'Pending' AND (bet_type = 'moneyline' OR bet_type IS NULL)"
-        params = []
+        where = "WHERE status != 'Pending'" + type_clause
+        params = list(type_params)
         if since:
             where += " AND date >= ?"
             params.append(since)
@@ -314,50 +354,52 @@ def get_roi_stats(since: Optional[str] = None) -> dict:
             params,
         ).fetchall()
 
+        # The pending count must use the SAME bet_type and date filters as the
+        # graded query. It previously ignored bet_type entirely, so a
+        # moneyline-only stat block reported the pending count for every market.
+        pending_sql = "SELECT COUNT(*) as cnt FROM predictions WHERE status = 'Pending'" + type_clause
+        pending_params = list(type_params)
+        if since:
+            pending_sql += " AND date >= ?"
+            pending_params.append(since)
+        pending_count = conn.execute(pending_sql, pending_params).fetchone()["cnt"]
+
     if not rows:
-        with get_connection() as conn:
-            pending_sql = "SELECT COUNT(*) as cnt FROM predictions WHERE status = 'Pending' AND (bet_type = 'moneyline' OR bet_type IS NULL)"
-            pending_params = []
-            if since:
-                pending_sql += " AND date >= ?"
-                pending_params.append(since)
-            pending_count = conn.execute(pending_sql, pending_params).fetchone()["cnt"]
         return {
-            "total_bets": 0, "wins": 0, "losses": 0, "pending": pending_count,
+            "total_bets": 0, "wins": 0, "losses": 0, "pushes": 0,
+            "pending": pending_count,
             "total_units_wagered": 0, "total_profit": 0.0,
             "roi_pct": 0.0, "brier_score": None, "win_rate": 0.0,
         }
 
     wins = sum(1 for r in rows if r["status"] == "Win")
     losses = sum(1 for r in rows if r["status"] == "Loss")
-    total_units = sum(r["units"] for r in rows)
+    pushes = sum(1 for r in rows if r["status"] == "Push")
+    decided = [r for r in rows if r["status"] in ("Win", "Loss")]
+    total_units = sum(r["units"] for r in decided)
     total_profit = sum(r["profit"] for r in rows if r["profit"] is not None)
 
-    # Brier score: mean squared error of predicted prob vs actual outcome
-    brier_sum = 0.0
-    for r in rows:
-        actual = 1.0 if r["status"] == "Win" else 0.0
-        brier_sum += (r["model_prob"] - actual) ** 2
-    brier_score = brier_sum / len(rows)
-
-    with get_connection() as conn:
-        pending_sql = "SELECT COUNT(*) as cnt FROM predictions WHERE status = 'Pending'"
-        pending_params = []
-        if since:
-            pending_sql += " AND date >= ?"
-            pending_params.append(since)
-        pending_count = conn.execute(pending_sql, pending_params).fetchone()["cnt"]
+    # Brier score: mean squared error of predicted prob vs actual outcome.
+    # Pushes have no binary outcome, so they are excluded.
+    brier_score = None
+    if decided:
+        brier_sum = sum(
+            (r["model_prob"] - (1.0 if r["status"] == "Win" else 0.0)) ** 2
+            for r in decided
+        )
+        brier_score = round(brier_sum / len(decided), 4)
 
     return {
         "total_bets": len(rows),
         "wins": wins,
         "losses": losses,
+        "pushes": pushes,
         "pending": pending_count,
         "total_units_wagered": total_units,
         "total_profit": round(total_profit, 2),
         "roi_pct": round((total_profit / total_units) * 100, 2) if total_units > 0 else 0.0,
-        "brier_score": round(brier_score, 4),
-        "win_rate": round((wins / len(rows)) * 100, 2) if rows else 0.0,
+        "brier_score": brier_score,
+        "win_rate": round((wins / len(decided)) * 100, 2) if decided else 0.0,
     }
 
 
@@ -419,7 +461,8 @@ def get_all_predictions() -> list[dict]:
                       status, result, profit, home_pitcher, away_pitcher,
                       bet_type, listed_total, predicted_total,
                       predicted_home_runs, predicted_away_runs, total_delta,
-                      confidence, raw_model_prob
+                      confidence, raw_model_prob,
+                      actual_home_score, actual_away_score, actual_total
                FROM predictions
                ORDER BY date DESC, id DESC""",
             conn,
@@ -427,7 +470,7 @@ def get_all_predictions() -> list[dict]:
     float_cols = [
         "model_prob", "implied_prob", "edge", "ev", "units", "profit",
         "listed_total", "predicted_total", "predicted_home_runs",
-        "predicted_away_runs", "total_delta", "raw_model_prob",
+        "predicted_away_runs", "total_delta", "raw_model_prob", "actual_total",
     ]
     for col in float_cols:
         if col in df.columns:

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -528,6 +528,7 @@ header .inner {
 .badge-pending { background: var(--neutral-bg); color: var(--text-2); }
 .badge-win     { background: var(--green-bg);   color: var(--green); }
 .badge-loss    { background: var(--red-bg);     color: var(--red);   }
+.badge-push    { background: var(--neutral-bg); color: var(--text-2); }
 
 /* Confidence (star rating) badge */
 .badge.conf-high { background: var(--green-bg);  color: var(--green); letter-spacing: .05em; }
@@ -712,6 +713,7 @@ tbody td:nth-child(10) { font-family: var(--font-mono); font-size: 12px; }
 tr.row-win  td:first-child { box-shadow: inset 4px 0 0 var(--green); }
 tr.row-loss td:first-child { box-shadow: inset 4px 0 0 var(--red); }
 tr.row-pending td:first-child { box-shadow: inset 4px 0 0 var(--border-strong); }
+tr.row-push    td:first-child { box-shadow: inset 4px 0 0 var(--text-3, var(--text-2)); }
 
 .profit-pos { color: var(--green); font-weight: 700; }
 .profit-neg { color: var(--red);   font-weight: 700; }

--- a/docs/js/dashboard.js
+++ b/docs/js/dashboard.js
@@ -114,12 +114,14 @@ function fmtProfit(n) {
 }
 
 function statusBadge(status) {
-  const cls = { Win: 'badge-win', Loss: 'badge-loss', Pending: 'badge-pending' }[status] ?? 'badge-pending';
+  const cls = { Win: 'badge-win', Loss: 'badge-loss', Push: 'badge-push',
+                Pending: 'badge-pending' }[status] ?? 'badge-pending';
   return `<span class="badge ${cls}">${status}</span>`;
 }
 
 function rowClass(status) {
-  return { Win: 'row-win', Loss: 'row-loss', Pending: 'row-pending' }[status] ?? 'row-pending';
+  return { Win: 'row-win', Loss: 'row-loss', Push: 'row-push',
+           Pending: 'row-pending' }[status] ?? 'row-pending';
 }
 
 function valueClass(n) {
@@ -174,18 +176,21 @@ function renderLastUpdated(iso) {
 // ── Stats computed from filtered history ──────────────────────────────────
 function computeStats(history, targetMode) {
   const rows = history.filter(p => inTimeRange(p, targetMode));
-  const graded  = rows.filter(p => p.status === 'Win' || p.status === 'Loss');
+  // A Push is graded but undecided: the stake is returned, so it counts in
+  // neither the W/L record nor the ROI denominator.
+  const decided = rows.filter(p => p.status === 'Win' || p.status === 'Loss');
+  const pushes  = rows.filter(p => p.status === 'Push').length;
   const pending = rows.filter(p => p.status === 'Pending').length;
-  const wins    = graded.filter(p => p.status === 'Win').length;
-  const losses  = graded.filter(p => p.status === 'Loss').length;
-  const wagered = graded.reduce((s, p) => s + (p.units ?? 0), 0);
-  const profit  = graded.reduce((s, p) => s + (p.profit ?? 0), 0);
+  const wins    = decided.filter(p => p.status === 'Win').length;
+  const losses  = decided.filter(p => p.status === 'Loss').length;
+  const wagered = decided.reduce((s, p) => s + (p.units ?? 0), 0);
+  const profit  = decided.reduce((s, p) => s + (p.profit ?? 0), 0);
   return {
-    wins, losses, pending,
+    wins, losses, pushes, pending,
     total_units_wagered: wagered,
     total_profit: profit,
     roi_pct:  wagered > 0 ? (profit / wagered) * 100 : 0,
-    win_rate: graded.length > 0 ? (wins / graded.length) * 100 : 0,
+    win_rate: decided.length > 0 ? (wins / decided.length) * 100 : 0,
   };
 }
 
@@ -199,14 +204,17 @@ function renderStats() {
 
   const wins    = s.wins    ?? 0;
   const losses  = s.losses  ?? 0;
+  const pushes  = s.pushes  ?? 0;
   const pending = s.pending ?? 0;
   const roi     = s.roi_pct ?? 0;
   const profit  = s.total_profit ?? 0;
   const winRate = s.win_rate ?? 0;
 
+  const pushSuffix = pushes > 0 ? `–${pushes}` : '';
+  const otherPushSuffix = (other.pushes ?? 0) > 0 ? `–${other.pushes}` : '';
   setHTML('card-record',
-    `<div class="value neutral">${wins}–${losses}</div>
-     <div class="sub">${pending} pending · ${otherLabel}: ${other.wins}–${other.losses}</div>`);
+    `<div class="value neutral">${wins}–${losses}${pushSuffix}</div>
+     <div class="sub">${pending} pending · ${otherLabel}: ${other.wins}–${other.losses}${otherPushSuffix}</div>`);
 
   setHTML('card-winrate',
     `<div class="value ${valueClass(winRate - 50)}">${fmt(winRate)}%</div>
@@ -358,6 +366,8 @@ function renderTodayTotals() {
 
 // ── Cumulative P&L chart ───────────────────────────────────────────────────
 function renderChart(history, currentMode) {
+  // Pushes are excluded on purpose: profit is 0, and the x-axis counts decided
+  // bets so the series stays consistent with the ROI denominator.
   let graded = history.filter(p =>
     (p.status === 'Win' || p.status === 'Loss') && inTimeRange(p, currentMode));
   graded = [...graded].sort((a, b) => a.date.localeCompare(b.date));

--- a/docs/model-review.md
+++ b/docs/model-review.md
@@ -1,0 +1,462 @@
+# Model performance review — 2026-08-16
+
+Diagnostic review of the MLB betting model after a stretch of poor results.
+Every number below is measured from `mlb_bets.db` (804 logged games, 768 graded
+picks) and the persisted model artifacts in `models/`, not estimated.
+
+---
+
+## Executive summary
+
+The model has **no out-of-sample predictive skill**. On the 777 graded games it
+logged for itself, its raw probability is 49.9% accurate — worse than a coin
+flip, worse than always picking the home team (52.8%), and worse than a constant
+prior. Its log loss (0.7198) is worse than pure market (0.6837) *and* worse than
+predicting the base rate every single game (0.6915).
+
+That is not variance. It is the downstream symptom of three upstream defects:
+
+1. **The training matrix is mostly constant.** Over half of every fetched
+   feature's training rows are the hard-coded league-average fallback.
+2. **Eight of twenty-five features meant different things in training and in
+   production** — a pure train/serve skew.
+3. **The training features leak.** They use full-season aggregates to predict
+   games played earlier in that same season.
+
+Two more defects then converted "no edge" into "worse than no edge":
+
+4. The moneyline pick gate has been **mathematically unsatisfiable since June**
+   — the pipeline has emitted zero moneyline picks for 55 days, silently.
+5. The totals score model is **off-scale by ~11%**, projecting ~0.5 runs under
+   the market and making 67% of all O/U picks Unders.
+
+Bottom line: **the model should not be staked until it can beat a constant
+prior out of sample.** The blend weight already knows this — it has been pinned
+at its 0.95 ceiling, meaning the unconstrained optimum is "ignore the model".
+
+---
+
+## Measured evidence
+
+### The model has negative information
+
+777 graded games from `model_log` (full slate, no adverse selection):
+
+| | Model | Market | Constant prior |
+|---|---|---|---|
+| Log loss | **0.7198** | 0.6837 | 0.6915 |
+| Brier | **0.2624** | 0.2454 | — |
+| Accuracy | **49.9%** | 54.3% | 52.8% |
+| Prob. std. dev. | 0.126 | 0.072 | — |
+
+The model is *more* dispersed than the market (0.126 vs 0.072) while being less
+accurate: it is confidently wrong. Its reliability curve is nearly flat and
+partly inverted — the games it likes least win more often than the games it
+likes most in the bottom half of the range:
+
+| Model says | Actually won | Market said |
+|---|---|---|
+| 0.318 | 0.505 | 0.474 |
+| 0.402 | 0.433 | 0.497 |
+| 0.462 | **0.660** | 0.516 |
+| 0.515 | 0.546 | 0.527 |
+| 0.561 | 0.443 | 0.536 |
+| 0.604 | 0.546 | 0.541 |
+| 0.659 | 0.526 | 0.550 |
+| 0.716 | 0.561 | 0.580 |
+
+A useful model's right column rises with its left. This one barely moves.
+
+For contrast, the **market** probabilities in the same table are well
+calibrated (0.417→0.442, 0.481→0.496, 0.544→0.512, 0.634→0.636), which confirms
+the odds pipeline is attaching the right prices to the right games. The problem
+is the model, not the market data.
+
+### The realized book
+
+| Market | Record | Units | Profit | ROI |
+|---|---|---|---|---|
+| Moneyline | 165–191 | 476.5 | +18.87 | +3.96% |
+| Totals | 204–192 | 368.6 | −4.75 | −1.29% |
+| **Combined** | **369–383** | **845.1** | **+14.12** | **+1.67%** |
+
+The moneyline ROI is *not* evidence of edge — it comes from 356 bets whose
+underlying probabilities are shown above to be noise, and it is well inside the
+standard error. It is also **frozen**: the last moneyline pick was 2026-06-22.
+
+---
+
+## Defects, in order of impact
+
+### 1. The training matrix is mostly league-average constants — CRITICAL
+
+`models/feature_medians.joblib`, written by the last training run, contains:
+
+```
+home_p_xFIP_season   4.2000     home_bullpen_era   4.0000
+home_p_SIERA_season  4.2000     home_bullpen_fip   4.0000
+home_p_K_BB_pct_...  10.0000    home_hit_wrc_plus  100.0000
+home_p_WHIP_season   1.3000     home_hit_ops       0.7400
+...
+```
+
+Every one of those is **exactly** the hard-coded fallback constant in
+`data.py` (`_default_pitcher_stats()`, `get_bullpen_stats()`,
+`get_team_hitting_splits()`). A median lands exactly on the fallback only if at
+least half the rows *are* the fallback. This holds for all 24 fetched features
+simultaneously — `park_factor` (0.99, from a static table) is the only feature
+with a real distribution.
+
+Note that `xFIP_season` and `SIERA_season` are computed from different inputs
+(FIP vs. ERA) and would essentially never be equal on real data, let alone both
+be exactly 4.20.
+
+The cause is structural: every fetch in `data.py` catches its own exception and
+returns a league-average constant. That is correct for one missing pitcher on a
+live slate, but during a bulk training build a failing endpoint quietly produces
+a full-size, signal-free matrix that trains and saves without complaint.
+`train_models()` then reports holdout metrics on that matrix and the pipeline
+carries on.
+
+**Fixed:** `features.check_feature_quality()` now measures and logs the
+fallback rate per feature, and `train.run_incremental_retrain()` aborts rather
+than overwriting a live model when any feature exceeds 25% fallbacks
+(`--allow-degraded-data` overrides).
+
+**Still to do:** find out *why* the fetches fail. The most likely culprit is
+`get_historical_game_data()`, which relies on `hydrate=probablePitcher` for
+*completed* seasons; MLB's schedule endpoint does not reliably populate
+`probablePitcher` on final games, so `home_pitcher_id` comes back `None` and
+`get_pitcher_stats()` returns defaults for every row. If so, pull the actual
+starter from each game's boxscore/linescore rather than the probable-pitcher
+hydrate. **Run a retrain and read the new fallback-rate log lines before
+trusting any model this repo produces.**
+
+### 2. Train/serve skew on eight features — CRITICAL
+
+`features.build_training_features()` calls `get_pitcher_stats(...,
+use_rolling=False)`, and that flag makes `data.py` copy each season value
+straight into its rolling slot:
+
+```python
+# data.get_pitcher_stats, training path
+rolling_stats = {
+    "xFIP_rolling": season_stats["xFIP_season"],   # identical, every row
+    ...
+}
+```
+
+At prediction time `use_rolling=True` fetches a real 30-day window. So eight of
+twenty-five model inputs were **exact duplicates of another column during
+training and carried genuinely different values in production**. The trees split
+arbitrarily between each duplicated pair — feature importance is near-uniform at
+~1/25 per column, the signature of a model finding nothing — and every one of
+those splits was then evaluated on a shifted distribution live.
+
+Two more columns, `home_hit_wrc_plus` / `away_hit_wrc_plus`, are perfectly
+collinear with their OPS counterparts by construction
+(`wrc_plus = 100 * ops / 0.720`).
+
+**Fixed:** both groups removed from `FEATURE_COLUMNS` (25 → 15 features). The
+schema hash change forces a full rebuild on the next retrain.
+
+**Still to do:** recent form is real signal and it should come back — but only
+once the *training* path can build genuine point-in-time windows. See
+"Recommended next work" below.
+
+### 3. Look-ahead leakage in training features — CRITICAL
+
+`build_training_features()` fetches season-level stats for the whole season and
+applies them to every game in it:
+
+```python
+pitcher_cache[hp_key] = get_pitcher_stats(hp_id, hp_name, season=season, ...)
+bullpen_cache[hb_key] = get_bullpen_stats(game["home_team"], season=season)
+hitting_cache[hh_key] = get_team_hitting_splits(..., season=season)
+```
+
+A game played on 2024-04-05 is therefore predicted using the pitcher's *final*
+2024 ERA, the team's *final* 2024 bullpen ERA, and the team's *final* 2024
+platoon OPS — all of which incorporate the outcome of that very game and every
+game after it. Holdout metrics computed on this matrix are meaningless, which is
+exactly why offline numbers looked acceptable while live performance is at
+chance.
+
+This is the single largest remaining item and is **not fixed in this change** —
+see "Recommended next work".
+
+### 4. The moneyline gate has been unsatisfiable since June — HIGH
+
+Because every probability is shrunk toward the market before the edge is
+measured, a pick's edge is capped at `(1 - weight) * MAX_RAW_DISAGREEMENT`.
+With `EV_THRESHOLD = 0.05` and a 0.15 cap, the filter becomes impossible to
+satisfy once `weight > 0.667`.
+
+The self-tuned weight has been pinned at its **0.95** ceiling since calibration
+began: max achievable edge `0.05 × 0.15 = 0.0075`, against a required 0.05 and
+a ~3.7% market overround. Simulating the live filter over all 777 logged games:
+
+| Blend weight | Picks generated | ROI |
+|---|---|---|
+| 0.30 | 268 | −3.26% |
+| 0.40 | 224 | +1.23% |
+| 0.50 | 153 | −0.77% |
+| 0.60 | 79 | −7.93% |
+| **0.667+** | **0** | — |
+| **0.95 (live)** | **0** | — |
+
+At 0.95 the count is zero even with the threshold set to 0.0 — the shrunk
+probability can never clear the vig. The database agrees: **zero moneyline picks
+since 2026-06-22.**
+
+Note the deeper point: at every weight that *does* produce picks, ROI is
+approximately zero or negative. So emitting nothing is the *right* answer for a
+model with no edge. The bug is not the silence — it is that the silence was
+**invisible**, reported as an ordinary "0 picks today", while the dashboard kept
+advertising a frozen +3.96% moneyline ROI as though the strategy were live.
+
+A related consequence: `compute_confidence()` computes
+`span = max_edge - EV_THRESHOLD`, which goes negative in this regime and made
+the function return 1 star for every pick.
+
+**Fixed:** `evaluate.edge_band()` reports reachability; the daily run prints and
+logs a warning when the gate is unreachable; the state is exported to
+`stats.json`; `compute_confidence()` now ranks against the achievable band
+instead of collapsing to a flat 1.
+
+**Deliberately not changed:** the thresholds themselves. Loosening them to force
+picks out of a model with no demonstrated edge would convert a harmless silence
+into an active losing strategy. That is a call for the owner to make once the
+model can beat a constant prior.
+
+### 5. The totals score model is off-scale — HIGH
+
+`score.py` divided the `xFIP` feature slot by `_LEAGUE_AVG_ERA = 4.50`. But that
+slot is not xFIP and not ERA: `data._compute_fip()` builds it as FIP with
+`_FIP_CONSTANT = 3.10`, whose league mean is ~4.00. Dividing a ~4.00-scale
+quantity by 4.50 multiplied every projection by ~0.89.
+
+Measured over 396 graded totals picks:
+
+- mean projected total **8.10** vs mean posted line **8.62** (−0.51 runs)
+- median gap **−1.06** runs
+- the model sat below the line on **67.4%** of games
+- resulting picks: **267 Unders vs 129 Overs**
+- Over-side ROI: **−19.08%** (adverse selection — the only Overs that cleared
+  the gate were those where a downward-biased estimator still exceeded the line)
+
+Two secondary errors compounded it: the `_LEAGUE_AVG_OPS = 0.720` reference did
+not match the 0.740 that `get_team_hitting_splits()` actually returns as its
+league default, and the projection attributed **100% of run prevention to the
+starting pitcher**, ignoring the bullpen features entirely even though relievers
+throw ~45% of innings. That left the projection swinging ~1.4 runs around lines
+that books move by ~0.4.
+
+**Fixed:** reference constants realigned to the scale of the features they
+normalize; bullpen blended in by innings share; response damped so extreme
+inputs stay in a plausible band. A league-average matchup now projects 8.79
+rather than 8.10.
+
+### 6. Odds could be matched to the wrong game in a series — MEDIUM
+
+`match_odds_to_games()` keyed its lookup on `(home_team, away_team)` only:
+
+```python
+for o in odds:
+    odds_lookup[(o["home_team"], o["away_team"])] = o   # last event wins
+```
+
+The-Odds-API returns every upcoming event, and MLB plays the same matchup on
+3–4 consecutive days. The last event for a matchup won the dict slot, so
+today's game could be priced off a later game in the same series — different
+starting pitcher, different line. `commence_time` was fetched and then never
+used.
+
+I could not confirm this fires in production (the logged market probabilities
+are well calibrated, which argues the API's return window is short), so treat it
+as a latent bug rather than a proven cause. It is cheap to close either way.
+
+**Fixed:** lookup keyed on `(home, away, commence_date)` with Eastern-time
+bucketing (a 10pm ET first pitch is the *next* day in UTC), earliest start
+winning a doubleheader, and a team-pair fallback when `commence_time` is absent.
+
+### 7. Totals prices averaged across different lines — MEDIUM
+
+`fetch_live_odds()` collected every book's Over price into one list, every Under
+price into another, and the posted lines into a third — then averaged all three
+independently. If book A posts 8.5 and book B posts 9.0, the result is a price
+pair belonging to *neither* line, attached to an averaged 8.75 line that nobody
+offered.
+
+**Fixed:** prices are bucketed by line; the most widely posted line wins, and
+only prices quoted at that line are averaged. `num_books_at_line` is exported.
+
+### 8. Every totals push was booked as a full-unit decision — MEDIUM
+
+`grade_predictions()` computed `"Over" if actual_total > listed else "Under"`.
+On a whole-number line (9.0) landing exactly on the total, the stake is
+returned — but this graded it as an Under, booking a **full-unit loss on every
+Over that pushed and a full-unit win on every Under that pushed**. With 267
+Under picks in the book, this materially distorts the recorded totals record in
+the Unders' favour.
+
+**Fixed:** pushes grade to `status = "Push"`, `profit = 0.0`, and are excluded
+from the win/loss record and the ROI denominator.
+
+### 9. Final scores were never stored — MEDIUM
+
+`grade_predictions()` computed `actual_total` and threw it away. That makes the
+totals model impossible to calibrate: `TOTALS_SIGMA`, the run-scale constants,
+and the residual centering all need real residuals to fit against.
+
+**Fixed:** `actual_home_score`, `actual_away_score`, and `actual_total` are now
+persisted at grading time and exported.
+
+### 10. Headline stats reported a market the model had stopped betting — MEDIUM
+
+`get_roi_stats()` filtered to `bet_type = 'moneyline'`, but `export_dashboard_data()`
+published the result under the generic keys `ytd` and `all_time`. Since the
+moneyline gate closed in June, the dashboard's headline has been a frozen
+snapshot of a strategy that no longer runs, while the *only* market actually
+being bet (totals, −1.29%) was invisible.
+
+The pending count inside the same function ignored the `bet_type` filter
+entirely, so a moneyline-only block reported every market's pending picks.
+
+**Fixed:** `get_roi_stats(bet_type=...)` scopes both the graded and pending
+queries consistently; `ytd`/`all_time` now cover all markets; a `by_bet_type`
+breakdown and the model-health flags are exported.
+
+### 11. Schema drift would have been silently zero-filled — LOW
+
+`predict_win_prob()` did `X.reindex(columns=model_cols, fill_value=0.0)`. Since
+0.0 is a *plausible-looking* value for every feature here — an ERA, FIP, or
+WHIP of 0.0 reads as an unhittable pitcher — a mismatch between a saved model
+and `FEATURE_COLUMNS` would produce confident nonsense rather than an error.
+
+**Fixed:** missing columns are imputed from training medians and logged at
+ERROR.
+
+### 12. Calibration failure had no alarm — LOW
+
+`blend_state.json` records `log_loss: 0.68419` against
+`pure_market_log_loss: 0.68373`. The best achievable blend is **worse than
+ignoring the model entirely**, and the chosen weight sits exactly on the
+`BLEND_WEIGHT_MAX` ceiling — meaning the grid search was cut off, not satisfied.
+Both facts were recorded in the state file and never acted on or surfaced.
+
+**Fixed:** `update_blend_weight()` now emits `weight_at_ceiling` and
+`model_adds_value`, logs at ERROR when blending cannot beat the market, and
+exports both to the dashboard.
+
+---
+
+## Recommended next work (not in this change)
+
+These are the items that actually restore an edge. They are ordered by expected
+value, and none of them is a config tweak.
+
+### A. Rebuild training features point-in-time — do this first
+
+Nothing else matters until the training matrix reflects what was knowable
+*before* first pitch. Concretely:
+
+- For each game date, fetch stats over `[season_start, game_date)` rather than
+  the whole season. `data._mlb_api_get` already speaks `byDateRange`; the
+  pitching leaderboard endpoint accepts the same window.
+- Cache one league-wide leaderboard **per date** (~180 calls/season, ~720 total)
+  instead of one per season. Team pitching and hitting splits can be pulled the
+  same way.
+- Guard the early season: with fewer than ~40 IP, regress the pitcher toward
+  league average (or toward prior-season performance) rather than using a
+  10-inning ERA at face value.
+- Once this exists, restore the `*_rolling` columns — they will finally mean
+  the same thing in training and production.
+
+Expect offline metrics to get **worse**, and that is the point: the current
+numbers are inflated by leakage. A leak-free holdout log loss below 0.687 is the
+first real evidence of skill.
+
+### B. Validate the way the model is actually used
+
+Replace the random-ish `CalibratedClassifierCV(cv=5)` on temporal data with
+walk-forward validation: train through date *T*, predict *T+1*, roll forward.
+Score it against the two benchmarks that matter — the constant home-win prior
+and the de-vigged market — not just against itself. If it cannot beat the
+constant prior out of sample, it is not ready to stake, full stop.
+
+### C. Add the features that actually move MLB games
+
+The current 15 inputs contain no measure of overall team strength. Highest-value
+additions, roughly in order:
+
+- **Team strength** — season-to-date run differential or a Pythagorean win
+  expectation for each side. This is the single biggest omission.
+- **Starter workload context** — days of rest, times through the order, recent
+  pitch counts. `get_pitcher_days_rest()` already exists in `data.py` and is
+  **never called by anything**.
+- **True bullpen split** — `get_bullpen_stats()` currently returns the whole
+  staff's ERA (its own docstring admits this), so the starter's contribution is
+  double-counted on both sides. Use the relievers-only split.
+- **Bullpen fatigue** — relief innings thrown in the last 3 days.
+- **Lineup quality** — the posted lineup, or at least a flag for missing
+  regulars. Team-level platoon OPS says nothing about who is playing today.
+- **Weather** — temperature and wind, which matter enormously for totals.
+- **Travel/schedule** — getaway days, time-zone changes, consecutive games.
+
+`BULLPEN_ROLLING_DAYS` is defined in `config.py`, accepted as a parameter by
+`get_bullpen_stats()`, and then never used — the function always returns
+season-to-date. Either implement it or drop it.
+
+### D. Fit the totals model against real residuals
+
+Now that `actual_total` is stored, after ~200 graded games:
+
+- Regress `actual_total` on `predicted_total` to recenter `_BASE_RUNS` and check
+  the slope (a slope well under 1 means the projection is still over-dispersed
+  and the elasticity constants need lowering).
+- Fit `TOTALS_SIGMA` from the residual standard deviation. The current **3.0 is
+  almost certainly too low** — the residual SD around a good MLB total
+  projection is nearer 4.0–4.3. Too small a sigma inflates P(Over)/P(Under),
+  overstates every edge, and oversizes every Kelly stake. I left it at 3.0
+  rather than substituting another guess; fit it from the data.
+
+### E. Fix bet sizing
+
+`size_bet()` computes half-Kelly and then multiplies by `KELLY_SCALE = 13`.
+That is not half-Kelly — it is 6.5× full Kelly, a bankroll-destroying fraction
+if it ever binds — and in practice it *does* bind: 53 bets landed on the 3.0u
+cap while 117 sat on the 0.5u floor. Between the arbitrary 13× multiplier and
+the clamps, the sizing carries almost no information about the actual edge. Pick
+a real fractional-Kelly (0.25–0.5×), express units as a genuine percentage of
+bankroll, and let the cap be a risk limit rather than the primary mechanism.
+
+### F. Shop lines instead of averaging them
+
+`fetch_live_odds()` averages implied probabilities across all books and bets the
+consensus. You bet at the **best available price**, not the average one. Use the
+consensus (ideally de-vigged per-book, then averaged) as the *fair-value*
+estimate, and the best available price for EV and staking. On a 3.7% overround
+this is worth roughly 1–2% ROI on its own — plausibly more than any model
+improvement listed above.
+
+---
+
+## What changed in this PR
+
+| File | Change |
+|---|---|
+| `score.py` | Reference constants realigned to feature scale; bullpen blended in by innings share; damped response |
+| `features.py` | Removed 8 skewed `*_rolling` + 2 collinear `*_wrc_plus` columns; shared row builder; `check_feature_quality()` |
+| `train.py` | Aborts retrain on degraded feature quality; `--allow-degraded-data` override |
+| `database.py` | Push grading; final scores persisted; `get_roi_stats(bet_type=...)` with consistent pending scoping |
+| `odds.py` | Date-scoped odds matching; totals prices bucketed by line |
+| `evaluate.py` | `edge_band()`; confidence no longer collapses to 1 star; pushes in stats output |
+| `calibration.py` | `weight_at_ceiling` / `model_adds_value` health flags with ERROR logging |
+| `main.py` | Warns when the pick gate is unreachable; exports per-market stats and health flags |
+| `model.py` | Schema drift imputes medians and logs instead of silently zero-filling |
+| `tests/` | 44 new regression tests (177 → 221) |
+
+No betting thresholds were loosened. The changes fix defects and make failure
+states visible; they do **not** by themselves give the model an edge. Items A–C
+above are what does that.

--- a/docs/model-review.md
+++ b/docs/model-review.md
@@ -121,7 +121,11 @@ carries on.
 **Fixed:** `features.check_feature_quality()` now measures and logs the
 fallback rate per feature, and `train.run_incremental_retrain()` aborts rather
 than overwriting a live model when any feature exceeds 25% fallbacks
-(`--allow-degraded-data` overrides).
+(`--allow-degraded-data` overrides). The abort returns a failure status that
+the CLI turns into a non-zero exit — both `weekly-retrain.yml` and the
+`|| python main.py --retrain` fallback in `daily-predict.yml` read the exit
+code, so a silent abort would have reported a green retrain that never ran and
+left the daily run predicting with a stale, schema-mismatched model.
 
 **Still to do:** find out *why* the fetches fail. The most likely culprit is
 `get_historical_game_data()`, which relies on `hydrate=probablePitcher` for
@@ -301,7 +305,10 @@ Under picks in the book, this materially distorts the recorded totals record in
 the Unders' favour.
 
 **Fixed:** pushes grade to `status = "Push"`, `profit = 0.0`, and are excluded
-from the win/loss record and the ROI denominator.
+from the win/loss record and the ROI denominator — server-side in
+`get_roi_stats()` and in `docs/js/dashboard.js`, which computes its own stats
+from the exported history and previously mapped only Win/Loss/Pending (an
+unknown status fell through to pending styling and vanished from the record).
 
 ### 9. Final scores were never stored — MEDIUM
 
@@ -455,7 +462,8 @@ improvement listed above.
 | `calibration.py` | `weight_at_ceiling` / `model_adds_value` health flags with ERROR logging |
 | `main.py` | Warns when the pick gate is unreachable; exports per-market stats and health flags |
 | `model.py` | Schema drift imputes medians and logs instead of silently zero-filling |
-| `tests/` | 44 new regression tests (177 → 221) |
+| `docs/js/dashboard.js`, `docs/css/style.css` | Render and account for the new `Push` status |
+| `tests/` | 48 new regression tests (177 → 225) |
 
 No betting thresholds were loosened. The changes fix defects and make failure
 states visible; they do **not** by themselves give the model an edge. Items A–C

--- a/evaluate.py
+++ b/evaluate.py
@@ -310,11 +310,44 @@ def compute_confidence(edge: float, ev: float,
     max_edge = (1.0 - weight) * max_disagreement
     span = max_edge - EV_THRESHOLD
     if span <= 0:
-        return 1
+        # The achievable band has collapsed below EV_THRESHOLD — see
+        # edge_band() below. Returning a flat 1 star (the old behaviour) made
+        # every pick look equally weak. Rank against the achievable band itself
+        # so the stars stay informative if a pick is somehow still produced.
+        if max_edge <= 0:
+            return 1
+        frac = edge / max_edge
+        return max(1, min(5, 1 + int(frac * 5)))
     frac = (edge - EV_THRESHOLD) / span
     if frac <= 0:
         return 1
     return min(5, 1 + int(frac * 5))
+
+
+def edge_band(max_disagreement: float = MAX_RAW_DISAGREEMENT,
+              weight: float | None = None) -> dict:
+    """Report whether a pick can mathematically clear EV_THRESHOLD right now.
+
+    Blending caps a pick's edge at ``(1 - weight) * max_disagreement``. When the
+    self-tuned weight rises above ``1 - EV_THRESHOLD / max_disagreement`` that
+    ceiling drops below EV_THRESHOLD and the filter becomes unsatisfiable: the
+    pipeline emits zero picks for that market every single day, with no error
+    and no warning. At the moneyline defaults (EV_THRESHOLD 0.05, cap 0.15) the
+    cutoff is weight > 0.667 — and the learned weight has been pinned at its
+    0.95 ceiling, so no moneyline pick has been possible for weeks.
+
+    Returns a dict with the weight, the achievable max edge, the required
+    threshold, and a ``reachable`` flag.
+    """
+    if weight is None:
+        weight = calibration.get_blend_weight()
+    max_edge = (1.0 - weight) * max_disagreement
+    return {
+        "weight": round(weight, 4),
+        "max_achievable_edge": round(max_edge, 5),
+        "required_edge": EV_THRESHOLD,
+        "reachable": max_edge >= EV_THRESHOLD,
+    }
 
 
 def format_picks(picks: list[dict]) -> str:
@@ -355,8 +388,10 @@ def format_stats(stats: dict) -> str:
     lines.append("  LIFETIME PERFORMANCE")
     lines.append("=" * 50)
     lines.append(f"  Total Bets:       {stats['total_bets']}")
-    lines.append(f"  Record:           {stats['wins']}W - {stats['losses']}L "
-                 f"({stats['win_rate']:.1f}%)")
+    record = f"{stats['wins']}W - {stats['losses']}L"
+    if stats.get("pushes"):
+        record += f" - {stats['pushes']}P"
+    lines.append(f"  Record:           {record} ({stats['win_rate']:.1f}%)")
     lines.append(f"  Pending:          {stats['pending']}")
     lines.append(f"  Units Wagered:    {stats['total_units_wagered']:.1f}")
     lines.append(f"  Total Profit:     {stats['total_profit']:+.2f}u")

--- a/features.py
+++ b/features.py
@@ -17,25 +17,73 @@ from data import (
 logger = logging.getLogger(__name__)
 
 # Feature column order (must match training and prediction).
+#
 # NOTE: is_home is intentionally excluded — it was constant (always 1) and
 # provided no discriminative signal during training.
+#
+# The eight *_rolling columns were REMOVED because they carried a train/serve
+# skew that silently destroyed the model. data.get_pitcher_stats() is called
+# with use_rolling=False on the training path, which copies each season value
+# straight into its rolling slot — so during training the rolling columns were
+# byte-identical duplicates of the season columns. At prediction time
+# use_rolling=True fetches a real 30-day window, so those same eight inputs
+# suddenly carried different values than anything the model saw while fitting.
+# The trees had split arbitrarily across the duplicate pairs (feature
+# importance was near-uniform at ~1/25 per column), and every one of those
+# splits was evaluated on a shifted distribution in production.
+#
+# The two *_wrc_plus columns were removed because they are perfectly collinear
+# with their OPS counterparts: data.get_team_hitting_splits() computes
+# wrc_plus = 100 * ops / 0.720, an exact affine transform, so they added no
+# information and only diluted split selection.
+#
+# Restoring genuine recent-form signal requires point-in-time rolling windows
+# on the TRAINING path too (see docs/model-review.md); until that exists,
+# season-to-date stats are the only inputs that mean the same thing in both
+# training and production.
 FEATURE_COLUMNS = [
-    # Home pitcher (season + rolling)
+    # Home pitcher (season to date)
     "home_p_xFIP_season", "home_p_SIERA_season", "home_p_K_BB_pct_season", "home_p_WHIP_season",
-    "home_p_xFIP_rolling", "home_p_SIERA_rolling", "home_p_K_BB_pct_rolling", "home_p_WHIP_rolling",
-    # Away pitcher (season + rolling)
+    # Away pitcher (season to date)
     "away_p_xFIP_season", "away_p_SIERA_season", "away_p_K_BB_pct_season", "away_p_WHIP_season",
-    "away_p_xFIP_rolling", "away_p_SIERA_rolling", "away_p_K_BB_pct_rolling", "away_p_WHIP_rolling",
     # Bullpens
     "home_bullpen_era", "home_bullpen_fip",
     "away_bullpen_era", "away_bullpen_fip",
     # Home team hitting vs away pitcher hand
-    "home_hit_wrc_plus", "home_hit_ops",
+    "home_hit_ops",
     # Away team hitting vs home pitcher hand
-    "away_hit_wrc_plus", "away_hit_ops",
+    "away_hit_ops",
     # Park factor
     "park_factor",
 ]
+
+
+def _assemble_row(home_pitcher: dict, away_pitcher: dict,
+                  home_bullpen: dict, away_bullpen: dict,
+                  home_hitting: dict, away_hitting: dict,
+                  park_factor: float) -> dict:
+    """Build one FEATURE_COLUMNS-shaped row from the raw stat dicts.
+
+    Shared by the prediction and training paths so the two can never drift
+    apart in column set or ordering.
+    """
+    return {
+        "home_p_xFIP_season": home_pitcher["xFIP_season"],
+        "home_p_SIERA_season": home_pitcher["SIERA_season"],
+        "home_p_K_BB_pct_season": home_pitcher["K_BB_pct_season"],
+        "home_p_WHIP_season": home_pitcher["WHIP_season"],
+        "away_p_xFIP_season": away_pitcher["xFIP_season"],
+        "away_p_SIERA_season": away_pitcher["SIERA_season"],
+        "away_p_K_BB_pct_season": away_pitcher["K_BB_pct_season"],
+        "away_p_WHIP_season": away_pitcher["WHIP_season"],
+        "home_bullpen_era": home_bullpen["bullpen_era"],
+        "home_bullpen_fip": home_bullpen["bullpen_fip"],
+        "away_bullpen_era": away_bullpen["bullpen_era"],
+        "away_bullpen_fip": away_bullpen["bullpen_fip"],
+        "home_hit_ops": home_hitting["ops"],
+        "away_hit_ops": away_hitting["ops"],
+        "park_factor": park_factor,
+    }
 
 
 def build_game_features(game: dict) -> Optional[dict]:
@@ -65,39 +113,10 @@ def build_game_features(game: dict) -> Optional[dict]:
             game["away_team"], game["home_pitcher_hand"]
         )
 
-        features = {
-            # Home pitcher
-            "home_p_xFIP_season": home_pitcher["xFIP_season"],
-            "home_p_SIERA_season": home_pitcher["SIERA_season"],
-            "home_p_K_BB_pct_season": home_pitcher["K_BB_pct_season"],
-            "home_p_WHIP_season": home_pitcher["WHIP_season"],
-            "home_p_xFIP_rolling": home_pitcher["xFIP_rolling"],
-            "home_p_SIERA_rolling": home_pitcher["SIERA_rolling"],
-            "home_p_K_BB_pct_rolling": home_pitcher["K_BB_pct_rolling"],
-            "home_p_WHIP_rolling": home_pitcher["WHIP_rolling"],
-            # Away pitcher
-            "away_p_xFIP_season": away_pitcher["xFIP_season"],
-            "away_p_SIERA_season": away_pitcher["SIERA_season"],
-            "away_p_K_BB_pct_season": away_pitcher["K_BB_pct_season"],
-            "away_p_WHIP_season": away_pitcher["WHIP_season"],
-            "away_p_xFIP_rolling": away_pitcher["xFIP_rolling"],
-            "away_p_SIERA_rolling": away_pitcher["SIERA_rolling"],
-            "away_p_K_BB_pct_rolling": away_pitcher["K_BB_pct_rolling"],
-            "away_p_WHIP_rolling": away_pitcher["WHIP_rolling"],
-            # Bullpens
-            "home_bullpen_era": home_bullpen["bullpen_era"],
-            "home_bullpen_fip": home_bullpen["bullpen_fip"],
-            "away_bullpen_era": away_bullpen["bullpen_era"],
-            "away_bullpen_fip": away_bullpen["bullpen_fip"],
-            # Hitting vs opposing pitcher hand
-            "home_hit_wrc_plus": home_hitting["wrc_plus"],
-            "home_hit_ops": home_hitting["ops"],
-            "away_hit_wrc_plus": away_hitting["wrc_plus"],
-            "away_hit_ops": away_hitting["ops"],
-            "park_factor": get_park_factor(game["home_team"]),
-        }
-
-        return features
+        return _assemble_row(
+            home_pitcher, away_pitcher, home_bullpen, away_bullpen,
+            home_hitting, away_hitting, get_park_factor(game["home_team"]),
+        )
 
     except Exception as e:
         logger.error(
@@ -194,33 +213,10 @@ def build_training_features(historical_games: pd.DataFrame) -> tuple[pd.DataFram
         home_hitting = hitting_cache[hh_key]
         away_hitting = hitting_cache[ah_key]
 
-        row = {
-            "home_p_xFIP_season": home_pitcher["xFIP_season"],
-            "home_p_SIERA_season": home_pitcher["SIERA_season"],
-            "home_p_K_BB_pct_season": home_pitcher["K_BB_pct_season"],
-            "home_p_WHIP_season": home_pitcher["WHIP_season"],
-            "home_p_xFIP_rolling": home_pitcher["xFIP_rolling"],
-            "home_p_SIERA_rolling": home_pitcher["SIERA_rolling"],
-            "home_p_K_BB_pct_rolling": home_pitcher["K_BB_pct_rolling"],
-            "home_p_WHIP_rolling": home_pitcher["WHIP_rolling"],
-            "away_p_xFIP_season": away_pitcher["xFIP_season"],
-            "away_p_SIERA_season": away_pitcher["SIERA_season"],
-            "away_p_K_BB_pct_season": away_pitcher["K_BB_pct_season"],
-            "away_p_WHIP_season": away_pitcher["WHIP_season"],
-            "away_p_xFIP_rolling": away_pitcher["xFIP_rolling"],
-            "away_p_SIERA_rolling": away_pitcher["SIERA_rolling"],
-            "away_p_K_BB_pct_rolling": away_pitcher["K_BB_pct_rolling"],
-            "away_p_WHIP_rolling": away_pitcher["WHIP_rolling"],
-            "home_bullpen_era": home_bullpen["bullpen_era"],
-            "home_bullpen_fip": home_bullpen["bullpen_fip"],
-            "away_bullpen_era": away_bullpen["bullpen_era"],
-            "away_bullpen_fip": away_bullpen["bullpen_fip"],
-            "home_hit_wrc_plus": home_hitting["wrc_plus"],
-            "home_hit_ops": home_hitting["ops"],
-            "away_hit_wrc_plus": away_hitting["wrc_plus"],
-            "away_hit_ops": away_hitting["ops"],
-            "park_factor": get_park_factor(game["home_team"]),
-        }
+        row = _assemble_row(
+            home_pitcher, away_pitcher, home_bullpen, away_bullpen,
+            home_hitting, away_hitting, get_park_factor(game["home_team"]),
+        )
 
         feature_rows.append(row)
         targets.append(game["home_win"])
@@ -235,5 +231,73 @@ def build_training_features(historical_games: pd.DataFrame) -> tuple[pd.DataFram
         "Built feature matrix: %d games x %d features. Home win rate: %.1f%%",
         len(X), len(FEATURE_COLUMNS), y.mean() * 100,
     )
+    check_feature_quality(X)
 
     return X, y
+
+
+# ---------------------------------------------------------------------------
+# Data-quality guard
+# ---------------------------------------------------------------------------
+#
+# Every upstream fetch in data.py swallows its exception and returns a
+# hard-coded league-average constant. That is the right behaviour for a single
+# missing pitcher on a live slate, but during a bulk training build it means a
+# broken endpoint, an expired scrape, or an unhydrated field degrades thousands
+# of rows to the SAME constant with nothing louder than a debug log — and the
+# resulting matrix trains a model that has no signal to find.
+#
+# This is not hypothetical: the medians persisted by the last training run
+# (models/feature_medians.joblib) are EXACTLY the fallback constants for all 24
+# non-park features (xFIP 4.20, SIERA 4.20, K-BB% 10.0, WHIP 1.30, bullpen
+# 4.00/4.00, OPS 0.740, wRC+ 100.0). A median lands exactly on the fallback
+# only if at least half the rows ARE the fallback.
+
+# Feature -> the league-average constant data.py substitutes on failure.
+FALLBACK_VALUES = {
+    "home_p_xFIP_season": 4.20, "away_p_xFIP_season": 4.20,
+    "home_p_SIERA_season": 4.20, "away_p_SIERA_season": 4.20,
+    "home_p_K_BB_pct_season": 10.0, "away_p_K_BB_pct_season": 10.0,
+    "home_p_WHIP_season": 1.30, "away_p_WHIP_season": 1.30,
+    "home_bullpen_era": 4.00, "away_bullpen_era": 4.00,
+    "home_bullpen_fip": 4.00, "away_bullpen_fip": 4.00,
+    "home_hit_ops": 0.740, "away_hit_ops": 0.740,
+}
+
+# Above this share of fallback rows a feature carries essentially no signal.
+MAX_FALLBACK_RATE = 0.25
+
+
+def feature_fallback_rates(X: pd.DataFrame) -> dict[str, float]:
+    """Fraction of rows equal to the league-average fallback, per feature."""
+    if X.empty:
+        return {c: 0.0 for c in FALLBACK_VALUES if c in X.columns}
+    return {
+        col: float((X[col] == val).mean())
+        for col, val in FALLBACK_VALUES.items()
+        if col in X.columns
+    }
+
+
+def check_feature_quality(X: pd.DataFrame,
+                          max_rate: float = MAX_FALLBACK_RATE) -> dict[str, float]:
+    """Log the per-feature fallback rate and flag degraded features.
+
+    Returns the rate map so callers (train.py) can abort a retrain rather than
+    overwrite a working model with one fitted on league-average constants.
+    """
+    rates = feature_fallback_rates(X)
+    degraded = {c: r for c, r in rates.items() if r > max_rate}
+
+    for col, rate in sorted(rates.items(), key=lambda kv: -kv[1]):
+        logger.info("Feature fallback rate — %-28s %.1f%%", col, rate * 100)
+
+    if degraded:
+        logger.error(
+            "DATA QUALITY: %d of %d features are league-average fallbacks in "
+            "more than %.0f%% of rows: %s. The upstream stat fetch is failing; "
+            "a model trained on this matrix will have no signal.",
+            len(degraded), len(rates), max_rate * 100,
+            ", ".join(f"{c} {r:.0%}" for c, r in sorted(degraded.items(), key=lambda kv: -kv[1])),
+        )
+    return rates

--- a/main.py
+++ b/main.py
@@ -24,7 +24,10 @@ from data import get_todays_games, get_yesterdays_results
 from features import build_game_features
 from model import load_model, predict_win_prob
 from odds import fetch_live_odds, match_odds_to_games
-from evaluate import filter_positive_ev, filter_totals_ev, format_picks, format_stats, compute_confidence
+from evaluate import (
+    filter_positive_ev, filter_totals_ev, format_picks, format_stats,
+    compute_confidence, edge_band,
+)
 from score import predict_game_scores
 from calibration import (
     log_model_predictions,
@@ -33,7 +36,7 @@ from calibration import (
     get_blend_weight,
     is_self_tuned,
 )
-from config import MARKET_BLEND_WEIGHT, TOTALS_MAX_DISAGREEMENT
+from config import MARKET_BLEND_WEIGHT, TOTALS_MAX_DISAGREEMENT, MAX_RAW_DISAGREEMENT
 
 logger = logging.getLogger(__name__)
 
@@ -296,6 +299,22 @@ def run_predictions(model_name: str = "xgboost", force: bool = False):
     print("\n  [5/5] Calculating EV and filtering picks...")
     print(f"        Market blend weight: {get_blend_weight():.2f} "
           f"({'self-tuned' if is_self_tuned() else 'default'})")
+
+    # A high blend weight can push the achievable edge below EV_THRESHOLD, at
+    # which point the moneyline filter is unsatisfiable and quietly returns
+    # nothing every day. Say so out loud instead of reporting "0 picks" as if
+    # the slate simply had no value.
+    band = edge_band()
+    if not band["reachable"]:
+        msg = (f"Moneyline gate is UNREACHABLE at blend weight {band['weight']:.2f}: "
+               f"max achievable edge {band['max_achievable_edge']:.4f} < "
+               f"EV_THRESHOLD {band['required_edge']:.4f}. Zero moneyline picks "
+               f"are possible until the weight drops below "
+               f"{1 - band['required_edge'] / MAX_RAW_DISAGREEMENT:.3f} or the "
+               f"threshold is lowered.")
+        print(f"        WARNING: {msg}")
+        logger.warning(msg)
+
     ml_picks = filter_positive_ev(games_with_odds)
     for p in ml_picks:
         p["confidence"] = compute_confidence(p["edge"], p["ev"])
@@ -440,14 +459,32 @@ def export_dashboard_data():
 
     ytd_since = f"{date.today().year}-01-01"
     blend_state = get_blend_state()
+    # ytd/all_time now cover EVERY market. They used to be moneyline-only while
+    # being labelled generically, so once the moneyline gate became unreachable
+    # the dashboard kept advertising a frozen moneyline ROI from bets the model
+    # had long stopped making, and the live totals book was invisible.
     stats = {
         "ytd": {**get_roi_stats(since=ytd_since), "since": ytd_since},
         "all_time": get_roi_stats(),
+        "by_bet_type": {
+            bt: {
+                "ytd": get_roi_stats(since=ytd_since, bet_type=bt),
+                "all_time": get_roi_stats(bet_type=bt),
+            }
+            for bt in ("moneyline", "totals")
+        },
         "model": {
             "blend_weight": get_blend_weight(),
             "self_tuned": is_self_tuned(),
             "calibration_games": (blend_state or {}).get("n_games", 0),
             "calibration_updated": (blend_state or {}).get("updated_at"),
+            "model_adds_value": (blend_state or {}).get("model_adds_value"),
+            "weight_at_ceiling": (blend_state or {}).get("weight_at_ceiling"),
+            "moneyline_edge_band": edge_band(),
+            "totals_edge_band": edge_band(
+                max_disagreement=TOTALS_MAX_DISAGREEMENT,
+                weight=MARKET_BLEND_WEIGHT,
+            ),
         },
         "last_updated": datetime.utcnow().isoformat() + "Z",
     }

--- a/main.py
+++ b/main.py
@@ -526,10 +526,15 @@ def export_dashboard_data():
 # Incremental retrain
 # ---------------------------------------------------------------------------
 
-def run_retrain(force: bool = False, tune: bool = False):
-    """Incremental model retrain entry point (used by CLI and scheduler)."""
+def run_retrain(force: bool = False, tune: bool = False) -> bool:
+    """Incremental model retrain entry point (used by CLI and scheduler).
+
+    Returns True when models were trained and saved, False when the run
+    aborted (no data, or a degraded feature matrix). The CLI turns False into
+    a non-zero exit so CI cannot mistake an aborted retrain for a green one.
+    """
     from train import run_incremental_retrain
-    run_incremental_retrain(force=force, tune=tune)
+    return bool(run_incremental_retrain(force=force, tune=tune))
 
 
 # ---------------------------------------------------------------------------
@@ -648,9 +653,11 @@ def main():
     # Determine action
     if args.train:
         from train import run_incremental_retrain
-        run_incremental_retrain(force=True, tune=args.tune)
+        if not run_incremental_retrain(force=True, tune=args.tune):
+            sys.exit(1)
     elif args.retrain:
-        run_retrain(force=args.force, tune=args.tune)
+        if not run_retrain(force=args.force, tune=args.tune):
+            sys.exit(1)
     elif args.run_now:
         run_predictions(model_name=args.model, force=args.force)
     elif args.grade:

--- a/model.py
+++ b/model.py
@@ -366,7 +366,24 @@ def predict_win_prob(model, features: dict) -> float:
             pass
 
     if model_cols:  # empty list is falsy — avoids zero-column DataFrame crash
-        X = X.reindex(columns=model_cols, fill_value=0.0)
+        missing = [c for c in model_cols if c not in X.columns]
+        if missing:
+            # Never silently zero-fill: 0.0 is a *plausible-looking* value for
+            # every feature here (an ERA/FIP/WHIP of 0.0 reads as an unhittable
+            # pitcher), so a schema drift between the saved model and
+            # FEATURE_COLUMNS would produce confident nonsense instead of an
+            # error. Impute from training medians and make the drift loud.
+            logger.error(
+                "Model expects %d feature(s) not produced by the current "
+                "FEATURE_COLUMNS: %s. Imputing training medians — retrain to "
+                "resync the schema.",
+                len(missing), missing,
+            )
+        fill = {c: medians.get(c, 0.0) for c in missing} if medians else None
+        X = X.reindex(columns=model_cols)
+        if fill:
+            X = X.fillna(value=fill)
+        X = X.fillna(0.0)
 
     proba = model.predict_proba(X)
     if proba.shape[1] != 2:

--- a/odds.py
+++ b/odds.py
@@ -77,10 +77,13 @@ def fetch_live_odds() -> list[dict]:
         # Averaging American odds directly is nonlinear — go through prob space instead.
         home_probs = []
         away_probs = []
-        # Totals market: over/under prices (prob space) and the posted line (points).
-        over_probs = []
-        under_probs = []
-        total_points = []
+        # Totals market: over/under prices bucketed BY LINE. Books post
+        # different totals for the same game (8.5 here, 9.0 there), and a price
+        # is only meaningful attached to its own line. Averaging every Over
+        # price together and pairing it with the average line — the old
+        # behaviour — produced a quote that belonged to no real market and
+        # systematically mispriced the O/U edge.
+        totals_by_line: dict[float, dict[str, list[float]]] = {}
 
         for bookmaker in event.get("bookmakers", []):
             for market in bookmaker.get("markets", []):
@@ -94,12 +97,13 @@ def fetch_live_odds() -> list[dict]:
                 elif key == "totals":
                     for outcome in market.get("outcomes", []):
                         point = outcome.get("point")
-                        if outcome["name"] == "Over":
-                            over_probs.append(american_to_implied_prob(outcome["price"]))
-                            if point is not None:
-                                total_points.append(point)
-                        elif outcome["name"] == "Under":
-                            under_probs.append(american_to_implied_prob(outcome["price"]))
+                        side = outcome.get("name")
+                        if point is None or side not in ("Over", "Under"):
+                            continue
+                        bucket = totals_by_line.setdefault(
+                            float(point), {"Over": [], "Under": []}
+                        )
+                        bucket[side].append(american_to_implied_prob(outcome["price"]))
 
         if not home_probs or not away_probs:
             continue
@@ -122,11 +126,24 @@ def fetch_live_odds() -> list[dict]:
             "total_line": None,
         }
 
-        # Consensus totals market (only if a book offered an O/U line).
-        if over_probs and under_probs and total_points:
-            record["over_odds"] = implied_prob_to_american(sum(over_probs) / len(over_probs))
-            record["under_odds"] = implied_prob_to_american(sum(under_probs) / len(under_probs))
-            record["total_line"] = round(sum(total_points) / len(total_points), 1)
+        # Consensus totals market: use the most widely posted line (the market
+        # consensus), and average only the prices quoted at that same line.
+        priced = {
+            line: sides for line, sides in totals_by_line.items()
+            if sides["Over"] and sides["Under"]
+        }
+        if priced:
+            # Most books first; ties broken by the lower line for determinism.
+            consensus_line = min(
+                priced, key=lambda ln: (-len(priced[ln]["Over"]), ln)
+            )
+            sides = priced[consensus_line]
+            record["over_odds"] = implied_prob_to_american(
+                sum(sides["Over"]) / len(sides["Over"]))
+            record["under_odds"] = implied_prob_to_american(
+                sum(sides["Under"]) / len(sides["Under"]))
+            record["total_line"] = consensus_line
+            record["num_books_at_line"] = len(sides["Over"])
 
         odds_list.append(record)
 
@@ -195,28 +212,66 @@ def american_to_decimal(odds: int) -> float:
         return (100.0 / abs(odds)) + 1.0
 
 
+def commence_date(commence_time: str) -> Optional[str]:
+    """Local (US/Eastern) calendar date for an event's UTC commence_time.
+
+    The-Odds-API stamps commence_time in UTC, so a 7pm ET first pitch is
+    23:00Z or (for late games) the following day in UTC. Bucketing by the raw
+    UTC date would push every night game onto tomorrow's slate, so convert to
+    Eastern — the calendar MLB schedules against — before taking the date.
+    """
+    if not commence_time:
+        return None
+    try:
+        from datetime import datetime, timezone, timedelta
+        ts = datetime.fromisoformat(commence_time.replace("Z", "+00:00"))
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        # Fixed -04:00 (EDT) covers the entire MLB regular season.
+        return (ts.astimezone(timezone(timedelta(hours=-4)))).date().isoformat()
+    except (ValueError, TypeError):
+        return None
+
+
 def match_odds_to_games(odds: list[dict], games: list[dict]) -> list[dict]:
     """Match fetched odds to today's game slate.
+
+    Odds are keyed by (home_team, away_team, commence_date). The-Odds-API
+    returns every upcoming event, not just today's, and MLB teams play the same
+    matchup on 3-4 consecutive days. Keying on the team pair alone (the old
+    behaviour) let the LAST event for a matchup win the dict slot, so today's
+    game could silently be priced off a future game in the same series — a
+    different starting pitcher, a different line. Including the date makes the
+    match exact, and events on other dates are ignored rather than substituted.
 
     Returns the games list enriched with odds data. Games without matching
     odds are excluded.
     """
-    odds_lookup = {}
+    odds_lookup: dict[tuple, dict] = {}
     for o in odds:
-        key = (o["home_team"], o["away_team"])
-        odds_lookup[key] = o
+        d = commence_date(o.get("commence_time", ""))
+        key = (o["home_team"], o["away_team"], d)
+        # Keep the earliest-starting event for a given matchup/date so a
+        # doubleheader resolves to game 1 rather than an arbitrary one.
+        prior = odds_lookup.get(key)
+        if prior is None or (o.get("commence_time") or "") < (prior.get("commence_time") or ""):
+            odds_lookup[key] = o
+
+    # Fallback index for events whose commence_time is missing or unparseable.
+    undated = {(o["home_team"], o["away_team"]): o
+               for o in odds if commence_date(o.get("commence_time", "")) is None}
 
     matched = []
     for game in games:
-        key = (game["home_team"], game["away_team"])
-        if key in odds_lookup:
-            game_with_odds = {**game, **odds_lookup[key]}
-            matched.append(game_with_odds)
+        pair = (game["home_team"], game["away_team"])
+        entry = odds_lookup.get((*pair, game["game_date"])) or undated.get(pair)
+        if entry is not None:
+            matched.append({**game, **entry})
         else:
             available = list(odds_lookup.keys())[:8]
             logger.warning(
-                "No odds found for %s @ %s — available keys (first 8): %s",
-                game["away_team"], game["home_team"], available,
+                "No odds found for %s @ %s on %s — available keys (first 8): %s",
+                game["away_team"], game["home_team"], game["game_date"], available,
             )
 
     logger.info("Matched odds for %d / %d games.", len(matched), len(games))

--- a/score.py
+++ b/score.py
@@ -1,37 +1,80 @@
 """Analytical score prediction — estimates expected runs per team using existing features."""
 
-_LEAGUE_AVG_ERA = 4.50
-_LEAGUE_AVG_OPS = 0.720
-_BASE_RUNS      = 4.5
-_HOME_ADV       = 1.02  # ~2% scoring bump for home team
+# --- League reference scales -------------------------------------------------
+# IMPORTANT: the "xFIP" feature slot is not a real xFIP. data._compute_fip()
+# builds it as FIP with _FIP_CONSTANT = 3.10, whose league mean is ~4.00 — NOT
+# the ~4.50 of league ERA. Dividing that slot by 4.50 (as this module used to)
+# multiplied every run estimate by ~0.89, pushing the projected total ~0.5 runs
+# below the market line on average and making ~2/3 of all totals picks Unders.
+# Every reference constant below must be on the same scale as the feature it
+# normalizes.
+_LEAGUE_AVG_FIP = 4.00      # mean of the FIP slot produced by data._compute_fip()
+_LEAGUE_AVG_BULLPEN = 4.00  # mean of bullpen_era / bullpen_fip
+_LEAGUE_AVG_OPS = 0.740     # matches data.get_team_hitting_splits' league default
+_BASE_RUNS = 4.35           # league-average runs per team per game
+_HOME_ADV = 1.02            # ~2% scoring bump for home team
+
+# The starter throws roughly 55% of a modern game's innings; the bullpen covers
+# the rest. Attributing 100% of run prevention to the starter (the old
+# behaviour) left the projection far more volatile than the market — the model
+# swung ~1.4 runs around the line where books move ~0.4. Weighting the two
+# staffs by innings share, and damping the response, keeps the estimate in a
+# realistic band.
+_STARTER_INNINGS_SHARE = 0.55
+_PITCHING_ELASTICITY = 0.70  # runs allowed move less than 1:1 with staff quality
+_HITTING_ELASTICITY = 0.90   # runs scored move slightly less than 1:1 with OPS
+
+
+def _damped_ratio(value: float, league_avg: float, elasticity: float) -> float:
+    """Ratio of `value` to `league_avg`, shrunk toward 1.0 by `elasticity`.
+
+    A raw ratio treats a 20%-better pitcher as suppressing 20% of runs, which
+    over-extrapolates: run scoring is a team outcome that only partly reflects
+    one input. Damping keeps the projection inside a plausible range.
+    """
+    if not league_avg:
+        return 1.0
+    return 1.0 + elasticity * ((value / league_avg) - 1.0)
 
 
 def predict_game_scores(features: dict) -> dict:
     """Estimate expected runs for home and away teams from game features.
 
-    Uses away starter xFIP and home team OPS to project home runs, and vice
-    versa for away runs.  The park factor applies to BOTH teams — they hit in
-    the same stadium — so e.g. Coors boosts the visitors' scoring too.
+    Runs allowed by a team are driven by that team's starting pitcher and its
+    bullpen, weighted by innings share; runs scored are driven by the batting
+    team's OPS against the opposing starter's hand. The park factor applies to
+    BOTH teams — they hit in the same stadium — so e.g. Coors boosts the
+    visitors' scoring too.
+
     Returns keys: predicted_home_score, predicted_away_score, predicted_total.
     """
-    home_xfip = features.get("away_p_xFIP_season", _LEAGUE_AVG_ERA) or _LEAGUE_AVG_ERA
-    away_xfip = features.get("home_p_xFIP_season", _LEAGUE_AVG_ERA) or _LEAGUE_AVG_ERA
-    home_ops  = features.get("home_hit_ops", _LEAGUE_AVG_OPS) or _LEAGUE_AVG_OPS
-    away_ops  = features.get("away_hit_ops", _LEAGUE_AVG_OPS) or _LEAGUE_AVG_OPS
-    park      = features.get("park_factor", 1.0) or 1.0
+    # The home team scores against the AWAY staff, and vice versa.
+    away_starter = features.get("away_p_xFIP_season") or _LEAGUE_AVG_FIP
+    home_starter = features.get("home_p_xFIP_season") or _LEAGUE_AVG_FIP
+    away_pen = features.get("away_bullpen_fip") or _LEAGUE_AVG_BULLPEN
+    home_pen = features.get("home_bullpen_fip") or _LEAGUE_AVG_BULLPEN
+    home_ops = features.get("home_hit_ops") or _LEAGUE_AVG_OPS
+    away_ops = features.get("away_hit_ops") or _LEAGUE_AVG_OPS
+    park = features.get("park_factor") or 1.0
+
+    s, p = _STARTER_INNINGS_SHARE, 1.0 - _STARTER_INNINGS_SHARE
+
+    # Effective staff quality faced by each offense, on the FIP scale.
+    away_staff = s * away_starter + p * (away_pen * _LEAGUE_AVG_FIP / _LEAGUE_AVG_BULLPEN)
+    home_staff = s * home_starter + p * (home_pen * _LEAGUE_AVG_FIP / _LEAGUE_AVG_BULLPEN)
 
     home_runs = round(
         _BASE_RUNS
-        * (home_xfip / _LEAGUE_AVG_ERA)
-        * (home_ops  / _LEAGUE_AVG_OPS)
+        * _damped_ratio(away_staff, _LEAGUE_AVG_FIP, _PITCHING_ELASTICITY)
+        * _damped_ratio(home_ops, _LEAGUE_AVG_OPS, _HITTING_ELASTICITY)
         * park
         * _HOME_ADV,
         2,
     )
     away_runs = round(
         _BASE_RUNS
-        * (away_xfip / _LEAGUE_AVG_ERA)
-        * (away_ops  / _LEAGUE_AVG_OPS)
+        * _damped_ratio(home_staff, _LEAGUE_AVG_FIP, _PITCHING_ELASTICITY)
+        * _damped_ratio(away_ops, _LEAGUE_AVG_OPS, _HITTING_ELASTICITY)
         * park,
         2,
     )

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -291,3 +291,146 @@ class TestGradeBackfillByDate:
                 "SELECT status, profit FROM predictions").fetchone()
         assert row["status"] == "Loss"
         assert row["profit"] == pytest.approx(-2)
+
+
+# ---------------------------------------------------------------------------
+# Totals push grading (regression)
+# ---------------------------------------------------------------------------
+
+class TestTotalsPushGrading:
+    """A whole-number O/U line landing exactly on the total is a PUSH.
+
+    grade_predictions used to compute `"Over" if actual_total > listed else
+    "Under"`, which booked a full-unit LOSS on every Over pick that pushed and
+    a full-unit WIN on every Under pick that pushed. Both are wrong: the stake
+    is returned.
+    """
+
+    def _totals_pick(self, pick, listed=9.0):
+        return _make_pick(
+            pick=pick, pick_side=pick, bet_type="totals", listed_total=listed,
+            predicted_total=listed + 0.5, units=1.0, odds=-110,
+        )
+
+    def _results(self, home=5, away=4):
+        return {"BOS @ NYY": {"home_score": home, "away_score": away,
+                              "winner": "NYY"}}
+
+    def test_over_on_exact_line_is_push_not_loss(self, tmp_db):
+        with patch("database.DB_PATH", tmp_db):
+            database.save_predictions([self._totals_pick("Over")], bet_type="totals")
+            database.grade_predictions(self._results(5, 4))  # total == 9.0
+        with get_conn(tmp_db) as conn:
+            row = conn.execute("SELECT * FROM predictions").fetchone()
+        assert row["status"] == "Push"
+        assert row["result"] == "Push"
+        assert row["profit"] == 0.0
+
+    def test_under_on_exact_line_is_push_not_win(self, tmp_db):
+        with patch("database.DB_PATH", tmp_db):
+            database.save_predictions([self._totals_pick("Under")], bet_type="totals")
+            database.grade_predictions(self._results(5, 4))
+        with get_conn(tmp_db) as conn:
+            row = conn.execute("SELECT * FROM predictions").fetchone()
+        assert row["status"] == "Push"
+        assert row["profit"] == 0.0
+
+    def test_half_line_never_pushes(self, tmp_db):
+        with patch("database.DB_PATH", tmp_db):
+            database.save_predictions(
+                [self._totals_pick("Over", listed=8.5)], bet_type="totals")
+            database.grade_predictions(self._results(5, 4))  # 9 > 8.5
+        with get_conn(tmp_db) as conn:
+            row = conn.execute("SELECT * FROM predictions").fetchone()
+        assert row["status"] == "Win"
+        assert row["profit"] > 0
+
+    def test_actual_score_is_recorded(self, tmp_db):
+        """Residuals must be persisted so TOTALS_SIGMA can be fit from them."""
+        with patch("database.DB_PATH", tmp_db):
+            database.save_predictions(
+                [self._totals_pick("Over", listed=8.5)], bet_type="totals")
+            database.grade_predictions(self._results(6, 3))
+        with get_conn(tmp_db) as conn:
+            row = conn.execute("SELECT * FROM predictions").fetchone()
+        assert row["actual_home_score"] == 6
+        assert row["actual_away_score"] == 3
+        assert row["actual_total"] == 9.0
+
+    def test_moneyline_scores_also_recorded(self, tmp_db):
+        with patch("database.DB_PATH", tmp_db):
+            database.save_predictions([_make_pick(units=1.0)])
+            database.grade_predictions(self._results(7, 2))
+        with get_conn(tmp_db) as conn:
+            row = conn.execute("SELECT * FROM predictions").fetchone()
+        assert row["status"] == "Win"
+        assert row["actual_total"] == 9.0
+
+
+# ---------------------------------------------------------------------------
+# get_roi_stats bet_type scoping (regression)
+# ---------------------------------------------------------------------------
+
+class TestRoiStatsBetType:
+    def _seed(self, tmp_db):
+        with patch("database.DB_PATH", tmp_db):
+            database.save_predictions([_make_pick(units=1.0)])
+            database.save_predictions(
+                [_make_pick(pick="Over", pick_side="Over", bet_type="totals",
+                            listed_total=8.5, units=1.0)],
+                bet_type="totals",
+            )
+            # One pending pick in each market.
+            database.save_predictions([_make_pick(date="2026-09-09", units=1.0)])
+            database.save_predictions(
+                [_make_pick(date="2026-09-09", pick="Under", pick_side="Under",
+                            bet_type="totals", listed_total=8.5, units=1.0)],
+                bet_type="totals",
+            )
+            database.grade_predictions(
+                {"BOS @ NYY": {"home_score": 5, "away_score": 4, "winner": "NYY"}},
+                for_date="2026-04-02",
+            )
+
+    def test_default_covers_every_market(self, tmp_db):
+        self._seed(tmp_db)
+        with patch("database.DB_PATH", tmp_db):
+            stats = database.get_roi_stats()
+        assert stats["total_bets"] == 2  # one moneyline + one totals
+
+    def test_bet_type_filters_graded_rows(self, tmp_db):
+        self._seed(tmp_db)
+        with patch("database.DB_PATH", tmp_db):
+            ml = database.get_roi_stats(bet_type="moneyline")
+            ou = database.get_roi_stats(bet_type="totals")
+        assert ml["total_bets"] == 1
+        assert ou["total_bets"] == 1
+
+    def test_pending_count_respects_bet_type(self, tmp_db):
+        """The pending count used to ignore bet_type entirely, so a
+        moneyline-only stat block reported every market's pending picks."""
+        self._seed(tmp_db)
+        with patch("database.DB_PATH", tmp_db):
+            ml = database.get_roi_stats(bet_type="moneyline")
+            ou = database.get_roi_stats(bet_type="totals")
+            everything = database.get_roi_stats()
+        assert ml["pending"] == 1
+        assert ou["pending"] == 1
+        assert everything["pending"] == 2
+
+    def test_pushes_excluded_from_roi_denominator(self, tmp_db):
+        with patch("database.DB_PATH", tmp_db):
+            database.save_predictions(
+                [_make_pick(pick="Over", pick_side="Over", bet_type="totals",
+                            listed_total=9.0, units=2.0)],
+                bet_type="totals",
+            )
+            database.grade_predictions(
+                {"BOS @ NYY": {"home_score": 5, "away_score": 4, "winner": "NYY"}})
+            stats = database.get_roi_stats()
+        assert stats["pushes"] == 1
+        assert stats["wins"] == 0 and stats["losses"] == 0
+        # A push must not count as a wagered unit, and must not divide by zero.
+        assert stats["total_units_wagered"] == 0
+        assert stats["roi_pct"] == 0.0
+        assert stats["win_rate"] == 0.0

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -13,7 +13,9 @@ from evaluate import (
     format_picks,
     format_stats,
 )
-from config import TOTALS_MAX_DISAGREEMENT
+from config import TOTALS_MAX_DISAGREEMENT, EV_THRESHOLD
+from unittest.mock import patch
+import calibration
 
 
 # ---------------------------------------------------------------------------
@@ -366,3 +368,60 @@ class TestFormatting:
         output = format_stats(stats)
         assert "Brier Score" in output
         assert "0.2123" in output
+
+
+# ---------------------------------------------------------------------------
+# edge_band — the silent dead zone (regression)
+# ---------------------------------------------------------------------------
+
+from evaluate import edge_band  # noqa: E402
+from config import MAX_RAW_DISAGREEMENT  # noqa: E402
+
+
+class TestEdgeBand:
+    """Blending caps a pick's edge at (1 - weight) * max_disagreement. Once the
+    self-tuned weight climbs past 1 - EV_THRESHOLD/cap that ceiling falls below
+    EV_THRESHOLD and the filter can never fire — the pipeline then emits zero
+    picks every day with no error at all. edge_band makes that state visible.
+    """
+
+    def test_reachable_at_default_weight(self):
+        band = edge_band(weight=0.5)
+        assert band["reachable"] is True
+        assert band["max_achievable_edge"] == pytest.approx(0.075, abs=1e-9)
+
+    def test_unreachable_at_the_learned_ceiling(self):
+        band = edge_band(weight=0.95)
+        assert band["reachable"] is False
+        assert band["max_achievable_edge"] < band["required_edge"]
+
+    def test_cutoff_is_where_the_band_equals_the_threshold(self):
+        cutoff = 1 - EV_THRESHOLD / MAX_RAW_DISAGREEMENT  # ~0.667
+        assert edge_band(weight=cutoff - 0.01)["reachable"] is True
+        assert edge_band(weight=cutoff + 0.01)["reachable"] is False
+
+    def test_no_moneyline_pick_survives_an_unreachable_band(self):
+        # Sanity-check the consequence end to end: at w=0.95 no game, however
+        # far the model strays from the market, can produce a pick.
+        assert edge_band(weight=0.95)["reachable"] is False
+        with patch.object(calibration, "get_blend_weight", lambda: 0.95):
+            for prob in (0.30, 0.42, 0.50, 0.58, 0.70):
+                game = _make_game(home_prob=prob, home_odds=+120, away_odds=-140)
+                assert filter_positive_ev([game]) == []
+
+    def test_totals_band_is_reachable_at_its_static_weight(self):
+        band = edge_band(max_disagreement=TOTALS_MAX_DISAGREEMENT, weight=0.5)
+        assert band["reachable"] is True
+
+
+class TestConfidenceWhenBandCollapses:
+    def test_stars_still_differentiate(self):
+        """compute_confidence returned a flat 1 for every pick once the span
+        went non-positive, erasing the rating entirely."""
+        stars = [compute_confidence(e, 0.01, weight=0.95) for e in (0.001, 0.004, 0.007)]
+        assert stars == sorted(stars)
+        assert max(stars) > min(stars)
+
+    def test_still_bounded_one_to_five(self):
+        for e in (0.0, 0.001, 0.5, 10.0):
+            assert 1 <= compute_confidence(e, 0.01, weight=0.95) <= 5

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -27,14 +27,24 @@ class TestFeatureColumns:
         )
 
     def test_expected_count(self):
-        # 8 home pitcher + 8 away pitcher + 4 bullpen + 4 hitting + 1 park = 25
-        assert len(FEATURE_COLUMNS) == 25
+        # 4 home pitcher + 4 away pitcher + 4 bullpen + 2 hitting + 1 park = 15
+        assert len(FEATURE_COLUMNS) == 15
 
-    def test_rolling_and_season_both_present(self):
-        season_feats = [f for f in FEATURE_COLUMNS if "_season" in f]
-        rolling_feats = [f for f in FEATURE_COLUMNS if "_rolling" in f]
-        assert len(season_feats) == 8
-        assert len(rolling_feats) == 8
+    def test_no_rolling_features(self):
+        # The *_rolling columns are produced with use_rolling=False during
+        # training (making them exact copies of the season columns) but with a
+        # real 30-day window at prediction time. That train/serve skew means
+        # they must not be model inputs until the training path can build
+        # genuine point-in-time windows.
+        assert [f for f in FEATURE_COLUMNS if "_rolling" in f] == []
+        assert len([f for f in FEATURE_COLUMNS if "_season" in f]) == 8
+
+    def test_no_collinear_wrc_plus(self):
+        # data.get_team_hitting_splits derives wrc_plus = 100 * ops / 0.720,
+        # an exact affine transform of ops — keeping both is pure redundancy.
+        assert [f for f in FEATURE_COLUMNS if "wrc_plus" in f] == []
+        assert "home_hit_ops" in FEATURE_COLUMNS
+        assert "away_hit_ops" in FEATURE_COLUMNS
 
     def test_no_duplicates(self):
         assert len(FEATURE_COLUMNS) == len(set(FEATURE_COLUMNS))

--- a/tests/test_odds.py
+++ b/tests/test_odds.py
@@ -253,3 +253,143 @@ class TestFetchLiveOddsTotals:
         assert rec["under_odds"] is None
         # Moneyline still parsed.
         assert "home_odds" in rec
+
+
+# ---------------------------------------------------------------------------
+# match_odds_to_games — date scoping (regression)
+# ---------------------------------------------------------------------------
+
+class TestMatchOddsSeriesScoping:
+    """The-Odds-API returns every upcoming event, and MLB plays the same
+    matchup on consecutive days. Keying the lookup on (home, away) alone let
+    the LAST event in a series overwrite the earlier ones, so today's game
+    could be priced off tomorrow's line and tomorrow's starting pitcher.
+    """
+
+    def _odds(self, home, away, commence, home_odds=-110):
+        return {"home_team": home, "away_team": away,
+                "home_odds": home_odds, "away_odds": -110,
+                "commence_time": commence}
+
+    def _game(self, home, away, game_date):
+        return {"home_team": home, "away_team": away, "game_date": game_date}
+
+    def test_series_game_does_not_clobber_todays_line(self):
+        # A three-game series: only the 2026-04-02 game should match.
+        series = [
+            self._odds("NYY", "BOS", "2026-04-02T23:05:00Z", home_odds=-110),
+            self._odds("NYY", "BOS", "2026-04-03T23:05:00Z", home_odds=-200),
+            self._odds("NYY", "BOS", "2026-04-04T23:05:00Z", home_odds=+150),
+        ]
+        result = match_odds_to_games(series, [self._game("NYY", "BOS", "2026-04-02")])
+        assert len(result) == 1
+        assert result[0]["home_odds"] == -110
+
+    def test_matches_middle_game_of_series(self):
+        series = [
+            self._odds("NYY", "BOS", "2026-04-02T23:05:00Z", home_odds=-110),
+            self._odds("NYY", "BOS", "2026-04-03T23:05:00Z", home_odds=-200),
+        ]
+        result = match_odds_to_games(series, [self._game("NYY", "BOS", "2026-04-03")])
+        assert result[0]["home_odds"] == -200
+
+    def test_game_with_no_event_on_that_date_is_excluded(self):
+        odds = [self._odds("NYY", "BOS", "2026-04-05T23:05:00Z")]
+        result = match_odds_to_games(odds, [self._game("NYY", "BOS", "2026-04-02")])
+        assert result == []
+
+    def test_late_night_game_stays_on_its_eastern_date(self):
+        # 22:10 ET first pitch is 02:10Z the NEXT day. Bucketing on the raw UTC
+        # date would push it onto tomorrow's slate and drop the match.
+        odds = [self._odds("LAD", "SF", "2026-04-03T02:10:00Z")]
+        result = match_odds_to_games(odds, [self._game("LAD", "SF", "2026-04-02")])
+        assert len(result) == 1
+
+    def test_missing_commence_time_still_matches(self):
+        # Back-compat: an event with no usable commence_time falls back to a
+        # team-pair match rather than being silently dropped.
+        odds = [{"home_team": "NYY", "away_team": "BOS",
+                 "home_odds": -125, "away_odds": +105}]
+        result = match_odds_to_games(odds, [self._game("NYY", "BOS", "2026-04-02")])
+        assert len(result) == 1
+        assert result[0]["home_odds"] == -125
+
+    def test_doubleheader_resolves_to_first_game(self):
+        odds = [
+            self._odds("NYY", "BOS", "2026-04-02T21:05:00Z", home_odds=+120),
+            self._odds("NYY", "BOS", "2026-04-02T17:05:00Z", home_odds=-140),
+        ]
+        result = match_odds_to_games(odds, [self._game("NYY", "BOS", "2026-04-02")])
+        assert len(result) == 1
+        assert result[0]["home_odds"] == -140
+
+
+# ---------------------------------------------------------------------------
+# fetch_live_odds — totals must be bucketed by line (regression)
+# ---------------------------------------------------------------------------
+
+class TestTotalsLineBucketing:
+    """Prices are only meaningful attached to their own line. Averaging every
+    Over price across books posting 8.5 AND 9.0, then pairing the result with
+    the average line (8.75), produced a quote belonging to no real market.
+    """
+
+    def _book(self, name, line, over_price, under_price):
+        return {"key": name, "markets": [{"key": "totals", "outcomes": [
+            {"name": "Over", "price": over_price, "point": line},
+            {"name": "Under", "price": under_price, "point": line},
+        ]}]}
+
+    def _h2h(self, name):
+        return {"key": name, "markets": [{"key": "h2h", "outcomes": [
+            {"name": "New York Yankees", "price": -130},
+            {"name": "Boston Red Sox", "price": +110},
+        ]}]}
+
+    def _fetch(self, bookmakers):
+        event = {"home_team": "New York Yankees", "away_team": "Boston Red Sox",
+                 "commence_time": "2026-04-02T23:05:00Z", "bookmakers": bookmakers}
+        resp = MagicMock()
+        resp.json.return_value = [event]
+        resp.raise_for_status.return_value = None
+        with patch.object(odds_mod, "ODDS_API_KEY", "test-key"), \
+             patch.object(odds_mod.requests, "get", return_value=resp):
+            return fetch_live_odds()[0]
+
+    def test_consensus_line_is_the_most_posted_not_the_average(self):
+        rec = self._fetch([
+            self._h2h("a"),
+            self._book("a", 8.5, -110, -110),
+            self._book("b", 8.5, -105, -115),
+            self._book("c", 9.0, +100, -120),
+        ])
+        # Two books at 8.5, one at 9.0 → 8.5 wins. The old code averaged the
+        # points to 8.67 and rounded to 8.7, a line nobody offered.
+        assert rec["total_line"] == 8.5
+        assert rec["num_books_at_line"] == 2
+
+    def test_prices_come_only_from_the_consensus_line(self):
+        rec = self._fetch([
+            self._h2h("a"),
+            self._book("a", 8.5, -110, -110),
+            self._book("b", 8.5, -110, -110),
+            self._book("c", 9.0, +180, -220),  # far-off line, extreme prices
+        ])
+        # The 9.0 book's prices must not leak into the 8.5 quote.
+        assert rec["over_odds"] == -110
+        assert rec["under_odds"] == -110
+
+    def test_one_sided_line_is_ignored(self):
+        rec = self._fetch([
+            self._h2h("a"),
+            {"key": "b", "markets": [{"key": "totals", "outcomes": [
+                {"name": "Over", "price": -110, "point": 9.5},
+            ]}]},
+            self._book("c", 8.5, -105, -115),
+        ])
+        assert rec["total_line"] == 8.5
+
+    def test_no_totals_market_leaves_fields_none(self):
+        rec = self._fetch([self._h2h("a")])
+        assert rec["total_line"] is None
+        assert rec["over_odds"] is None

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -2,13 +2,24 @@
 
 import pytest
 
-from score import predict_game_scores, _BASE_RUNS
+from score import (
+    predict_game_scores, _BASE_RUNS, _LEAGUE_AVG_FIP, _LEAGUE_AVG_BULLPEN,
+    _LEAGUE_AVG_OPS,
+)
 
 
 def _features(park=1.0, **overrides):
+    """A perfectly league-average matchup.
+
+    These MUST be score.py's own league reference constants. The fixture used
+    to hard-code xFIP 4.50 / OPS 0.720, which are not the league means of those
+    feature slots — the same mismatch that biased every projection ~0.5 runs
+    under the market line.
+    """
     base = {
-        "home_p_xFIP_season": 4.50, "away_p_xFIP_season": 4.50,
-        "home_hit_ops": 0.720, "away_hit_ops": 0.720,
+        "home_p_xFIP_season": _LEAGUE_AVG_FIP, "away_p_xFIP_season": _LEAGUE_AVG_FIP,
+        "home_bullpen_fip": _LEAGUE_AVG_BULLPEN, "away_bullpen_fip": _LEAGUE_AVG_BULLPEN,
+        "home_hit_ops": _LEAGUE_AVG_OPS, "away_hit_ops": _LEAGUE_AVG_OPS,
         "park_factor": park,
     }
     base.update(overrides)
@@ -42,3 +53,78 @@ class TestPredictGameScores:
     def test_missing_features_fall_back_to_league_average(self):
         scores = predict_game_scores({})
         assert scores["predicted_total"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Run-scale calibration (regression)
+# ---------------------------------------------------------------------------
+
+class TestRunScaleMatchesTheFeatureScale:
+    """The "xFIP" slot is FIP built with data._FIP_CONSTANT = 3.10, whose league
+    mean is ~4.00 — not the ~4.50 of league ERA. Dividing it by 4.50 scaled
+    every projection by ~0.89, so the model sat ~0.5 runs under the market line
+    and 67% of all totals picks were Unders (with the Over side running -19%
+    ROI on the picks that did clear).
+    """
+
+    MARKET_TOTAL_RANGE = (8.0, 9.5)  # typical MLB posted totals
+
+    def test_league_average_game_lands_on_a_realistic_market_total(self):
+        total = predict_game_scores(_features())["predicted_total"]
+        lo, hi = self.MARKET_TOTAL_RANGE
+        assert lo <= total <= hi, (
+            f"league-average projection {total} is outside the range books "
+            f"actually post; the reference constants are off-scale"
+        )
+
+    def test_reference_constants_are_on_the_feature_scale(self):
+        from unittest.mock import patch
+        import data as data_mod
+        # The FIP slot's league mean must sit near the FIP constant plus the
+        # usual ~0.9 defense-independent component, nowhere near league ERA.
+        assert data_mod._FIP_CONSTANT < _LEAGUE_AVG_FIP < data_mod._FIP_CONSTANT + 1.5
+        # The OPS reference must be the same league-average value that
+        # data.get_team_hitting_splits substitutes when a split is
+        # unavailable; if the two drift apart the under-bias reappears.
+        with patch.object(data_mod, "_team_id_from_abbrev", return_value=None):
+            league_default = data_mod.get_team_hitting_splits("__none__", "R", season=2026)
+        assert league_default["ops"] == _LEAGUE_AVG_OPS
+
+    def test_bullpen_is_actually_used(self):
+        """The bullpen throws ~45% of innings. Ignoring it (the old behaviour)
+        made the projection swing on the starter alone."""
+        good_pen = predict_game_scores(_features(away_bullpen_fip=3.00))
+        bad_pen = predict_game_scores(_features(away_bullpen_fip=5.50))
+        assert bad_pen["predicted_home_score"] > good_pen["predicted_home_score"]
+
+    def test_starter_outweighs_bullpen(self):
+        starter_swing = (
+            predict_game_scores(_features(away_p_xFIP_season=5.5))["predicted_home_score"]
+            - predict_game_scores(_features(away_p_xFIP_season=3.0))["predicted_home_score"]
+        )
+        pen_swing = (
+            predict_game_scores(_features(away_bullpen_fip=5.5))["predicted_home_score"]
+            - predict_game_scores(_features(away_bullpen_fip=3.0))["predicted_home_score"]
+        )
+        assert starter_swing > pen_swing > 0
+
+    def test_extreme_starter_stays_in_a_plausible_band(self):
+        """A raw ratio treated a 33%-better pitcher as suppressing 33% of runs.
+        Damping keeps even extreme inputs inside a believable range."""
+        vs_ace = predict_game_scores(_features(away_p_xFIP_season=2.00))
+        vs_scrub = predict_game_scores(_features(away_p_xFIP_season=7.00))
+        assert 2.5 < vs_ace["predicted_home_score"]
+        assert vs_scrub["predicted_home_score"] < 8.0
+
+    def test_no_systematic_under_bias_across_a_realistic_slate(self):
+        """Sweep plausible matchups; the mean projection must straddle a
+        typical 8.5 line rather than sitting persistently beneath it."""
+        totals = []
+        for starter in (3.0, 3.5, 4.0, 4.5, 5.0):
+            for ops in (0.690, 0.720, 0.740, 0.760, 0.790):
+                totals.append(predict_game_scores(_features(
+                    home_p_xFIP_season=starter, away_p_xFIP_season=starter,
+                    home_hit_ops=ops, away_hit_ops=ops,
+                ))["predicted_total"])
+        mean_total = sum(totals) / len(totals)
+        assert 8.2 <= mean_total <= 9.2, f"mean projection {mean_total:.2f}"

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,6 +1,7 @@
 """Tests for incremental retrain helpers in train.py."""
 
 import json
+import sys
 import pytest
 import numpy as np
 import pandas as pd
@@ -395,10 +396,15 @@ class TestRetrainAbortsOnDegradedData:
                             lambda s: called.__setitem__("state", True))
         monkeypatch.setattr(train_mod, "load_training_state", lambda: {})
 
-        train_mod.run_incremental_retrain(force=True, current_year=2026)
+        result = train_mod.run_incremental_retrain(force=True, current_year=2026)
 
         assert called["train"] is False, "trained a model on league-average constants"
         assert called["state"] is False, "recorded a training run that never happened"
+        # Both weekly-retrain.yml and the retrain fallback in daily-predict.yml
+        # treat a zero exit as a successful retrain. A silent abort would leave
+        # the pipeline predicting with a stale/schema-mismatched model while CI
+        # reports green, so the abort MUST be reportable as a failure.
+        assert result is False
 
     def test_override_flag_allows_training(self, tmp_path, monkeypatch):
         import train as train_mod
@@ -413,9 +419,10 @@ class TestRetrainAbortsOnDegradedData:
         monkeypatch.setattr(train_mod, "save_training_state", lambda s: None)
         monkeypatch.setattr(train_mod, "load_training_state", lambda: {})
 
-        train_mod.run_incremental_retrain(force=True, current_year=2026,
-                                          allow_degraded_data=True)
+        result = train_mod.run_incremental_retrain(force=True, current_year=2026,
+                                                   allow_degraded_data=True)
         assert called["train"] is True
+        assert result is True
 
     def test_clean_build_trains_normally(self, tmp_path, monkeypatch):
         import train as train_mod
@@ -430,5 +437,49 @@ class TestRetrainAbortsOnDegradedData:
         monkeypatch.setattr(train_mod, "save_training_state", lambda s: None)
         monkeypatch.setattr(train_mod, "load_training_state", lambda: {})
 
-        train_mod.run_incremental_retrain(force=True, current_year=2026)
+        result = train_mod.run_incremental_retrain(force=True, current_year=2026)
         assert called["train"] is True
+        assert result is True
+
+
+class TestRetrainExitStatus:
+    """A data-quality abort must surface as a non-zero exit status.
+
+    .github/workflows/weekly-retrain.yml runs `python main.py --retrain`
+    directly, and daily-predict.yml uses it as the `|| python main.py --retrain`
+    fallback behind a missing-model / schema-change gate. Both read the exit
+    code, so returning normally would report a green retrain that never ran.
+    """
+
+    def test_no_training_data_reports_failure(self, monkeypatch):
+        import train as train_mod
+        monkeypatch.setattr(train_mod, "get_or_build_season_features",
+                            lambda season, force_rebuild: (
+                                pd.DataFrame(columns=FEATURE_COLUMNS),
+                                pd.Series([], dtype=int, name="home_win")))
+        monkeypatch.setattr(train_mod, "load_training_state", lambda: {})
+        assert train_mod.run_incremental_retrain(force=True, current_year=2026) is False
+
+    def test_main_retrain_exits_non_zero_on_abort(self, monkeypatch):
+        import main as main_mod
+        monkeypatch.setattr(main_mod, "run_retrain", lambda **kw: False)
+        monkeypatch.setattr(main_mod, "init_db", lambda: None)
+        monkeypatch.setattr(sys, "argv", ["main.py", "--retrain"])
+        with pytest.raises(SystemExit) as exc:
+            main_mod.main()
+        assert exc.value.code == 1
+
+    def test_main_retrain_exits_zero_on_success(self, monkeypatch):
+        import main as main_mod
+        monkeypatch.setattr(main_mod, "run_retrain", lambda **kw: True)
+        monkeypatch.setattr(main_mod, "init_db", lambda: None)
+        monkeypatch.setattr(sys, "argv", ["main.py", "--retrain"])
+        main_mod.main()  # must not raise SystemExit
+
+    def test_run_retrain_forwards_the_status(self, monkeypatch):
+        import main as main_mod
+        import train as train_mod
+        monkeypatch.setattr(train_mod, "run_incremental_retrain", lambda **kw: False)
+        assert main_mod.run_retrain() is False
+        monkeypatch.setattr(train_mod, "run_incremental_retrain", lambda **kw: True)
+        assert main_mod.run_retrain() is True

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -303,3 +303,132 @@ class TestRunIncrementalRetrain:
         assert "feature_columns_hash" in state
         assert "2023" in state["seasons"]
         assert "2026" in state["seasons"]
+
+
+# ---------------------------------------------------------------------------
+# Feature data-quality guard (regression)
+# ---------------------------------------------------------------------------
+
+import pandas as pd  # noqa: E402
+from features import (  # noqa: E402
+    FALLBACK_VALUES, MAX_FALLBACK_RATE, check_feature_quality,
+    feature_fallback_rates,
+)
+
+
+def _matrix(n=100, fallback_rows=0):
+    """n rows of realistic values, with `fallback_rows` degraded to defaults."""
+    rows = []
+    for i in range(n):
+        row = {}
+        for col in FEATURE_COLUMNS:
+            fb = FALLBACK_VALUES.get(col)
+            if fb is None:                      # park_factor
+                row[col] = 0.97 + (i % 5) * 0.01
+            elif i < fallback_rows:
+                row[col] = fb                   # upstream fetch failed
+            else:
+                row[col] = fb * (1.0 + ((i % 7) + 1) * 0.02)
+        rows.append(row)
+    return pd.DataFrame(rows, columns=FEATURE_COLUMNS)
+
+
+class TestFeatureQualityGuard:
+    """data.py swallows every upstream failure and returns a league-average
+    constant. In a bulk training build that silently turns a broken endpoint
+    into a full-size, signal-free matrix — which is exactly what the persisted
+    medians show happened (every one equals its fallback constant).
+    """
+
+    def test_clean_matrix_has_no_fallbacks(self):
+        rates = feature_fallback_rates(_matrix(fallback_rows=0))
+        assert rates
+        assert max(rates.values()) == 0.0
+
+    def test_fully_degraded_matrix_is_detected(self):
+        rates = feature_fallback_rates(_matrix(n=100, fallback_rows=100))
+        assert min(rates.values()) == 1.0
+
+    def test_rate_is_measured_per_feature(self):
+        rates = feature_fallback_rates(_matrix(n=100, fallback_rows=40))
+        for col, rate in rates.items():
+            assert rate == pytest.approx(0.40, abs=1e-9), col
+
+    def test_check_flags_only_above_threshold(self, caplog):
+        import logging
+        with caplog.at_level(logging.ERROR):
+            check_feature_quality(_matrix(n=100, fallback_rows=10))
+        assert "DATA QUALITY" not in caplog.text
+
+        caplog.clear()
+        with caplog.at_level(logging.ERROR):
+            check_feature_quality(_matrix(n=100, fallback_rows=90))
+        assert "DATA QUALITY" in caplog.text
+
+    def test_park_factor_is_not_a_fallback_feature(self):
+        # park_factor comes from a static table, never from a failing fetch.
+        assert "park_factor" not in FALLBACK_VALUES
+
+    def test_every_fetched_feature_has_a_known_fallback(self):
+        fetched = [c for c in FEATURE_COLUMNS if c != "park_factor"]
+        assert set(fetched) == set(FALLBACK_VALUES)
+
+    def test_threshold_is_a_sane_fraction(self):
+        assert 0.0 < MAX_FALLBACK_RATE < 1.0
+
+    def test_empty_matrix_does_not_crash(self):
+        assert check_feature_quality(pd.DataFrame(columns=FEATURE_COLUMNS)) is not None
+
+
+class TestRetrainAbortsOnDegradedData:
+    def test_degraded_build_does_not_train_or_save_state(self, tmp_path, monkeypatch):
+        import train as train_mod
+
+        degraded = _matrix(n=200, fallback_rows=200)
+        y = pd.Series([1, 0] * 100, name="home_win")
+        monkeypatch.setattr(train_mod, "get_or_build_season_features",
+                            lambda season, force_rebuild: (degraded, y))
+        called = {"train": False, "state": False}
+        monkeypatch.setattr(train_mod, "train_models",
+                            lambda *a, **k: called.__setitem__("train", True))
+        monkeypatch.setattr(train_mod, "save_training_state",
+                            lambda s: called.__setitem__("state", True))
+        monkeypatch.setattr(train_mod, "load_training_state", lambda: {})
+
+        train_mod.run_incremental_retrain(force=True, current_year=2026)
+
+        assert called["train"] is False, "trained a model on league-average constants"
+        assert called["state"] is False, "recorded a training run that never happened"
+
+    def test_override_flag_allows_training(self, tmp_path, monkeypatch):
+        import train as train_mod
+
+        degraded = _matrix(n=200, fallback_rows=200)
+        y = pd.Series([1, 0] * 100, name="home_win")
+        monkeypatch.setattr(train_mod, "get_or_build_season_features",
+                            lambda season, force_rebuild: (degraded, y))
+        called = {"train": False}
+        monkeypatch.setattr(train_mod, "train_models",
+                            lambda *a, **k: called.__setitem__("train", True))
+        monkeypatch.setattr(train_mod, "save_training_state", lambda s: None)
+        monkeypatch.setattr(train_mod, "load_training_state", lambda: {})
+
+        train_mod.run_incremental_retrain(force=True, current_year=2026,
+                                          allow_degraded_data=True)
+        assert called["train"] is True
+
+    def test_clean_build_trains_normally(self, tmp_path, monkeypatch):
+        import train as train_mod
+
+        clean = _matrix(n=200, fallback_rows=0)
+        y = pd.Series([1, 0] * 100, name="home_win")
+        monkeypatch.setattr(train_mod, "get_or_build_season_features",
+                            lambda season, force_rebuild: (clean, y))
+        called = {"train": False}
+        monkeypatch.setattr(train_mod, "train_models",
+                            lambda *a, **k: called.__setitem__("train", True))
+        monkeypatch.setattr(train_mod, "save_training_state", lambda s: None)
+        monkeypatch.setattr(train_mod, "load_training_state", lambda: {})
+
+        train_mod.run_incremental_retrain(force=True, current_year=2026)
+        assert called["train"] is True

--- a/train.py
+++ b/train.py
@@ -10,7 +10,10 @@ from datetime import date, datetime
 
 from config import TRAINING_SEASONS, LOG_FILE, CACHE_DIR, TRAINING_STATE_PATH
 from data import get_historical_game_data
-from features import build_training_features, FEATURE_COLUMNS
+from features import (
+    build_training_features, check_feature_quality, FEATURE_COLUMNS,
+    MAX_FALLBACK_RATE,
+)
 from model import train_models, tune_hyperparameters
 
 logger = logging.getLogger(__name__)
@@ -88,7 +91,8 @@ def get_or_build_season_features(
     return X, y
 
 
-def run_incremental_retrain(force: bool = False, current_year: int | None = None, tune: bool = False):
+def run_incremental_retrain(force: bool = False, current_year: int | None = None,
+                            tune: bool = False, allow_degraded_data: bool = False):
     """Retrain models using cached features for completed seasons.
 
     Completed seasons (year < current_year) load from parquet cache.
@@ -100,6 +104,8 @@ def run_incremental_retrain(force: bool = False, current_year: int | None = None
         force: Wipe all caches and rebuild from scratch.
         current_year: Override the current year (used in tests).
         tune: If True, run Optuna hyperparameter tuning before training.
+        allow_degraded_data: Train even when most feature values are
+            league-average fallbacks. Off by default — see check_feature_quality.
     """
     if current_year is None:
         current_year = date.today().year
@@ -160,6 +166,24 @@ def run_incremental_retrain(force: bool = False, current_year: int | None = None
     print(f"\n  Combined: {len(X_combined)} games across {len(all_X)} seasons.")
     print(f"  Home win rate: {y_combined.mean():.3f}\n")
 
+    # Refuse to replace a live model with one fitted on league-average
+    # constants. data.py falls back to a fixed constant whenever an upstream
+    # fetch fails, so a broken endpoint yields a full-size, entirely
+    # signal-free training matrix that trains and saves without complaint.
+    rates = check_feature_quality(X_combined)
+    degraded = {c: r for c, r in rates.items() if r > MAX_FALLBACK_RATE}
+    if degraded:
+        worst = ", ".join(
+            f"{c} {r:.0%}" for c, r in sorted(degraded.items(), key=lambda kv: -kv[1])[:5]
+        )
+        print(f"\n  ERROR: aborting retrain — {len(degraded)} feature(s) are mostly "
+              f"league-average fallbacks (worst: {worst}).")
+        print("  Fix the upstream stat fetch, then retrain. "
+              "Re-run with --allow-degraded-data to override.")
+        logger.error("Retrain aborted: degraded feature quality (%s).", worst)
+        if not allow_degraded_data:
+            return
+
     tuned_params = None
     if tune:
         print("\n  Running Optuna hyperparameter tuning (this may take several minutes)...")
@@ -184,6 +208,12 @@ def main():
         action="store_true",
         help="Run Optuna hyperparameter tuning before training (adds ~5-10 min on CPU).",
     )
+    parser.add_argument(
+        "--allow-degraded-data",
+        action="store_true",
+        help="Train even if most feature values are league-average fallbacks "
+             "(i.e. the upstream stat fetch is failing). Not recommended.",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -197,7 +227,8 @@ def main():
     print(f"\nMLB Betting Model — Full Training Pipeline")
     print(f"Seasons: {TRAINING_SEASONS} + current year (auto-detected)")
     print("=" * 50)
-    run_incremental_retrain(force=True, tune=args.tune)
+    run_incremental_retrain(force=True, tune=args.tune,
+                            allow_degraded_data=args.allow_degraded_data)
 
 
 if __name__ == "__main__":

--- a/train.py
+++ b/train.py
@@ -106,6 +106,14 @@ def run_incremental_retrain(force: bool = False, current_year: int | None = None
         tune: If True, run Optuna hyperparameter tuning before training.
         allow_degraded_data: Train even when most feature values are
             league-average fallbacks. Off by default — see check_feature_quality.
+
+    Returns:
+        True when models were trained and saved, False when the run aborted.
+        Callers that are CI entry points MUST translate False into a non-zero
+        exit status: both .github/workflows/weekly-retrain.yml and the retrain
+        fallback in daily-predict.yml treat a zero exit as a successful
+        retrain, so a silent abort would leave the pipeline predicting with a
+        stale or schema-mismatched model while the workflow reports green.
     """
     if current_year is None:
         current_year = date.today().year
@@ -156,7 +164,7 @@ def run_incremental_retrain(force: bool = False, current_year: int | None = None
     if not all_X:
         print("\n  ERROR: No training data available across all seasons. Aborting.")
         logger.error("No training data available. Aborting retrain.")
-        return
+        return False
 
     # Seasons are iterated in chronological order (TRAINING_SEASONS + current year),
     # so ignore_index=True simply resets the integer index while preserving temporal order.
@@ -182,7 +190,7 @@ def run_incremental_retrain(force: bool = False, current_year: int | None = None
               "Re-run with --allow-degraded-data to override.")
         logger.error("Retrain aborted: degraded feature quality (%s).", worst)
         if not allow_degraded_data:
-            return
+            return False
 
     tuned_params = None
     if tune:
@@ -198,6 +206,7 @@ def run_incremental_retrain(force: bool = False, current_year: int | None = None
     }
     save_training_state(new_state)
     print("\n  Training state saved. Models ready.")
+    return True
 
 
 def main():
@@ -227,8 +236,10 @@ def main():
     print(f"\nMLB Betting Model — Full Training Pipeline")
     print(f"Seasons: {TRAINING_SEASONS} + current year (auto-detected)")
     print("=" * 50)
-    run_incremental_retrain(force=True, tune=args.tune,
-                            allow_degraded_data=args.allow_degraded_data)
+    ok = run_incremental_retrain(force=True, tune=args.tune,
+                                 allow_degraded_data=args.allow_degraded_data)
+    if not ok:
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Diagnostic review of the model after the recent stretch of poor results, plus fixes for the defects found. Full write-up lands in `docs/model-review.md`.

## The finding

The model has **no out-of-sample predictive skill**. Measured on the 777 graded games it logged for itself:

| | Model | Market | Constant prior |
|---|---|---|---|
| Log loss | **0.7198** | 0.6837 | 0.6915 |
| Brier | **0.2624** | 0.2454 | — |
| Accuracy | **49.9%** | 54.3% | 52.8% |
| Prob. std. dev. | 0.126 | 0.072 | — |

It is worse than the market, worse than always picking the home team, and worse than predicting the base rate every game — while being *more* dispersed than the market. Its reliability curve is nearly flat and partly inverted. That is a broken pipeline, not variance.

The market probabilities in the same log are well calibrated, which rules out the odds feed as the cause.

## Root causes

**1. The training matrix is mostly constant.** Every median in `models/feature_medians.joblib` equals its hard-coded league-average fallback *exactly*, across all 24 fetched features (xFIP 4.20, SIERA 4.20, K-BB% 10.0, WHIP 1.30, bullpen 4.00/4.00, OPS 0.740, wRC+ 100.0). A median lands exactly on the fallback only if at least half the rows *are* the fallback. `data.py` swallows every upstream failure and substitutes a constant, so a broken endpoint silently produces a full-size, signal-free matrix that trains and saves without complaint.

**2. Train/serve skew on 8 of 25 features.** `get_pitcher_stats(use_rolling=False)` copies season values straight into the rolling slots during training, so those 8 columns were byte-identical duplicates while fitting and carried real 30-day windows in production. Feature importance is near-uniform at ~1/25 per column — the signature of a model finding nothing. Two more columns (`*_wrc_plus`) are perfectly collinear with their OPS counterparts by construction.

**3. Look-ahead leakage.** Training uses full-season aggregates to predict games played earlier in that same season, so a game on 2024-04-05 is predicted with the pitcher&#39;s final 2024 ERA. Holdout metrics on that matrix are meaningless.

## Two defects that made it worse

**The moneyline gate has been mathematically unsatisfiable since June.** Edge caps at `(1 - weight) × 0.15`; at the pinned 0.95 weight that is 0.0075 against a required 0.05. Simulated over all 777 logged games:

| Blend weight | Picks | ROI |
|---|---|---|
| 0.40 | 224 | +1.23% |
| 0.50 | 153 | −0.77% |
| 0.60 | 79 | −7.93% |
| **0.667+ / 0.95 (live)** | **0** | — |

Zero moneyline picks since 2026-06-22 — silently, reported as an ordinary &#34;0 picks today&#34; while the dashboard kept advertising a frozen +3.96% moneyline ROI. Note that ROI is ≈0 or negative at *every* weight that produces picks, so emitting nothing is the right answer here; the bug is that it was invisible.

**The totals score model is off-scale by ~11%.** `score.py` divided the &#34;xFIP&#34; slot by 4.50, but that slot is FIP built with a 3.10 constant (league mean ~4.00). Over 396 graded totals picks: mean projection **8.10** vs mean line **8.62**, below the line on **67.4%** of games, **267 Unders vs 129 Overs**, Over-side ROI **−19.08%**.

## What this PR changes

| File | Change |
|---|---|
| `score.py` | Reference constants realigned to feature scale; bullpen blended in by innings share; damped response |
| `features.py` | Drop 8 skewed `*_rolling` + 2 collinear `*_wrc_plus` columns (25→15); shared row builder; `check_feature_quality()` |
| `train.py` | Abort retrain on degraded feature quality (non-zero exit); `--allow-degraded-data` override |
| `database.py` | Grade totals pushes as pushes (was booking full-unit wins/losses); persist final scores; `get_roi_stats(bet_type=...)` with consistent pending scoping |
| `odds.py` | Date-scoped odds matching so a later game in a series can&#39;t clobber today&#39;s line; bucket totals prices by line |
| `evaluate.py` | `edge_band()`; confidence no longer collapses to 1 star; pushes in stats output |
| `calibration.py` | `weight_at_ceiling` / `model_adds_value` health flags with ERROR logging |
| `main.py` | Warn when the pick gate is unreachable; export per-market stats and health flags; propagate retrain failure to exit code |
| `model.py` | Impute medians and log on schema drift rather than zero-filling (0.0 is a plausible-looking ERA/FIP/WHIP) |
| `docs/js/dashboard.js`, `docs/css/style.css` | Render and account for the new `Push` status |

**No betting thresholds were loosened.** Forcing picks out of a model with no demonstrated edge would convert a harmless silence into an active losing strategy — that call belongs to the owner once the model can beat a constant prior.

## Testing

48 new regression tests, 177 → **225 passing**. Each covers a specific defect: totals pushes, series odds clobbering (including the ET/UTC date boundary and doubleheaders), totals line bucketing, the run-scale bias, the unreachable edge band, `bet_type` scoping, the data-quality guard, and the retrain exit status.

## Review follow-ups (commit 2)

Both Codex findings were real and are fixed in `5ffc7e7`:

- **Retrain abort was silent to CI.** `run_incremental_retrain()` returned normally when it refused to train on a degraded matrix, so `python main.py --retrain` exited 0 and both workflows read that as a successful retrain. Sharper than it first looked on `daily-predict.yml`: the `FEATURE_COLUMNS` change here alters the schema hash, so its gate *will* fire a retrain on the first run after merge — an exit-0 abort would have fallen through to `--run-now` with a stale, schema-mismatched model. Now returns a status the CLI turns into exit 1.
- **`Push` was unrenderable in the dashboard.** `docs/js/dashboard.js` computes its own stats from the exported history and mapped only Win/Loss/Pending, so a push would have rendered pending-colored and vanished from the record and P&L. Added `Push` to `statusBadge`/`rowClass` with its own styling, and split `computeStats` into decided vs pushed so the stake stays out of the ROI denominator.

## What this does *not* fix

These changes remove defects and make failure states visible; they do **not** by themselves give the model an edge. `docs/model-review.md` details the work that does, in priority order:

- **Rebuild training features point-in-time** (highest value — nothing else matters until the matrix reflects what was knowable before first pitch; expect offline metrics to get *worse*, which is the point)
- **Walk-forward validation** against the constant prior and the de-vigged market, not just against itself
- **Add team strength** — run differential / Pythagorean expectation. There is currently no measure of overall team quality in the feature set at all.
- Fit `TOTALS_SIGMA` from the residuals now being stored (3.0 is almost certainly too low; ~4.0–4.3 is realistic)
- Fix bet sizing — `KELLY_SCALE = 13` applied to half-Kelly is 6.5× full Kelly, and it binds (53 bets at the cap, 117 at the floor)
- Shop lines instead of betting the average — likely worth more ROI than any model improvement above

Also flagged: `get_pitcher_days_rest()` and `BULLPEN_ROLLING_DAYS` exist and are never used, and `get_bullpen_stats()` returns whole-staff ERA rather than a relievers-only split, double-counting the starter on both sides.

**Before trusting any model this repo produces after merge:** run a retrain and read the new fallback-rate log lines. The likely culprit for root cause 1 is `hydrate=probablePitcher` not populating on completed games, which would make the fix a boxscore lookup rather than anything to do with the model itself.

---
_Generated by [Claude Code](https://claude.ai/code/session_014Qc86529nXWHa9QNg3BxfU)_